### PR TITLE
Add translation of kmers

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,7 +10,8 @@ makedocs(
         "Indexing & modifying kmers"     => "transforms.md",
         "Predicates"                     => "predicates.md",
         "Random kmers"                   => "random.md",
-        "Iterating over Kmers"           => "iteration.md"
+        "Iterating over Kmers"           => "iteration.md",
+        "Translation"                    => "translate.md",
         #"Pattern matching and searching" => "sequence_search.md",
         #"Iteration"                      => "iteration.md",
         #"Counting"                       => "counting.md",

--- a/docs/src/translate.md
+++ b/docs/src/translate.md
@@ -1,0 +1,21 @@
+```@meta
+CurrentModule = Kmers
+DocTestSetup = quote
+    using Kmers
+end
+```
+
+# Translating and reverse translating
+
+## Translating
+Just like other `BioSequence`s, `Kmer`s of RNA or DNA alphabets can be efficiently translated to amino acids:
+
+```
+julia> kmer = RNAKmer("AUGGGCCACUGA");
+
+julia> translate(kmer)
+AminoAcid 4-mer:
+MGH*
+```
+
+For more information on translation and different genetic codes, see the documentation of BioSequences.jl.

--- a/src/Kmers.jl
+++ b/src/Kmers.jl
@@ -88,6 +88,7 @@ export
     AminoAcidAlphabet,
     DNAAlphabet,
     RNAAlphabet,
+    translate,
     
     
     ###

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -141,14 +141,14 @@ end
 
 throw_translate_err(K) = error("Cannot translate Kmer of size $K not divisible by 3")
 
-@inline function setup_translate(seq::Kmer{<:RNAAlphabet, K}) where K
+@inline function setup_translate(seq::Kmer{<:NucleicAcidAlphabet, K}) where K
     naa, rem = divrem(K, 3)
     iszero(rem) || throw_translate_err(K)
     kmertype(AAKmer{naa})
 end
 
 function BioSequences.translate(
-    seq::RNAKmer;
+    seq::Union{RNAKmer, DNAKmer};
     code=BioSequences.standard_genetic_code,
     allow_ambiguous_codons::Bool = true, # a noop for this method
 )   
@@ -167,16 +167,16 @@ function BioSequences.translate(
 end
 
 function BioSequences.translate(
-    seq::Kmer{<:RNAAlphabet};
+    seq::Kmer{<:NucleicAcidAlphabet};
     code=BioSequences.standard_genetic_code,
     allow_ambiguous_codons::Bool = true,
 )    
     T = setup_translate(seq)
     data = blank_ntuple(T)
     for i in 1:ksize(T)
-        a = seq[3*i - 2]
-        b = seq[3*i - 1]
-        c = seq[3*i - 0]
+        a = reinterpret(RNA, seq[3*i - 2])
+        b = reinterpret(RNA, seq[3*i - 1])
+        c = reinterpret(RNA, seq[3*i - 0])
         aa = if BioSequences.isambiguous(a) | BioSequences.isambiguous(b) | BioSequences.isambiguous(c)
             aa_ = BioSequences.try_translate_ambiguous_codon(code, a, b, c)
             if aa_ === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ if GROUP == "BioSequences" || GROUP == "All"
     include("mismatches.jl")
     include("debruijn_neighbors.jl")
     include("iteration.jl")
+    include("translation.jl")
     #include("shuffle.jl")
 end
 

--- a/test/translation.jl
+++ b/test/translation.jl
@@ -1,0 +1,43 @@
+@testset "Translation" begin
+
+sampler = BioSequences.SamplerWeighted(
+    dna"ACGTMRSVWYHKDBN",
+    vcat(fill(0.225, 4), fill(0.00909, 10))
+)
+
+for A in (RNAAlphabet, DNAAlphabet)
+    for N in (2, 4)
+        for len in [3, 15, 33, 66]
+            for alternative in (true, false)
+                seq = if N == 2
+                    randseq(A{2}(), len)
+                else
+                    randseq(A{4}(), sampler, len)
+                end
+                kmer = Kmer{A{N}}(seq)
+                @test (
+                    translate(seq, alternative_start=alternative) ==
+                    translate(kmer, alternative_start=alternative)
+                )          
+            end
+        end
+    end
+end
+
+# Throws when ambiguous
+@test_throws Exception translate(
+    Kmer{RNAAlphabet{4}}("AUGCCGCMA"),
+    allow_ambiguous_codons=false
+)
+
+# Not divisible by 3
+@test_throws Exception translate(mer"UG"r)
+@test_throws Exception translate(mer"TAGCTTAA"d)
+@test_throws Exception translate(mer"CUGUAGUUGUCGC"r)
+@test_throws Exception translate(mer"AGCGA"d)
+
+# Cannot transla AA seq
+@test_throws MethodError translate(mer"LLVM"aa)
+@test_throws MethodError translate(mer"ATG"aa)
+
+end # translation


### PR DESCRIPTION
# Add translation of kmers
This add translation of kmers. It should work just like translation of `LongSequence`.

Resolves #9 

## Todo
- [x] Make kw nonstandard start work
- [x] Make translation of DNA kmers work
- [x] Add tests
- [x] Add documentation
- [x] Make sure code coverage is near 100%
- [x] Micro-optimise the hell out of it

## Types of changes
This PR implements the following changes:
* [X] :sparkles: New feature (A non-breaking change which adds functionality).

## :clipboard: Additional detail
Again, I envision it working exactly like the existing `translate` method for LongSequence.

## Discussion points
* Is the keyword `alternative_start` needed for kmers? Probably not. Is it worth slowing down the code to make the interface exactly like `LongSequence`?
