### PR TITLE
Resolve ambiguity error Kmer()

### DIFF
--- a/src/kmer.jl
+++ b/src/kmer.jl
@@ -242,7 +242,7 @@ Construct a `Kmer{A,K,N}` from an iterable.
 This is a convenience method which will work out the correct `N` parameter, for
 your given choice of `A` & `K`.
 """
-function Kmer{A,K}(itr) where {A,K}
+@inline function Kmer{A,K}(itr) where {A,K}
     T = kmertype(Kmer{A,K})
     return T(itr)
 end
@@ -258,7 +258,16 @@ the correct `N` parameter, for your given choice of `A` & `K`.
 !!! warning
     Since this gets K from runtime values, this is gonna be slow!
 """
-Kmer{A}(itr) where {A} = Kmer{A,length(itr)}(itr)
+@inline Kmer{A}(itr) where {A} = Kmer{A,length(itr)}(itr)
+@inline Kmer(seq::BioSequence{A}) where A = Kmer{A}(seq)
+
+function Kmer{A1}(seq::BioSequence{A2}) where {A1 <: NucleicAcidAlphabet, A2 <: NucleicAcidAlphabet}
+    kmertype(Kmer{A1, length(seq)})(seq)
+end
+
+@inline function Kmer{A}(nts::Vararg{Union{DNA, RNA}, K}) where {A <: NucleicAcidAlphabet, K}
+    return kmertype(Kmer{A, K})(nts)
+end
 
 """
     Kmer(nts::Vararg{DNA,K}) where {K}
@@ -273,10 +282,7 @@ DNA 5-mer:
 TTAGC
 ```
 """
-@inline function Kmer(nts::Vararg{DNA,K}) where {K}
-    T = kmertype(DNAKmer{K})
-    return T(nts)
-end
+@inline Kmer(nts::Vararg{DNA}) = DNAKmer(nts)
 
 """
     Kmer(nts::Vararg{RNA,K}) where {K}
@@ -291,10 +297,7 @@ DNA 5-mer:
 UUAGC
 ```
 """
-@inline function Kmer(nts::Vararg{RNA,K}) where {K}
-    T = kmertype(RNAKmer{K})
-    return T(nts)
-end
+@inline Kmer(nts::Vararg{RNA}) = RNAKmer(nts)
 
 """
     Kmer(seq::String)

--- a/src/kmer.jl
+++ b/src/kmer.jl
@@ -282,7 +282,7 @@ DNA 5-mer:
 TTAGC
 ```
 """
-@inline Kmer(nts::Vararg{DNA}) = DNAKmer(nts)
+@inline Kmer(nt::DNA, nts::Vararg{DNA}) = DNAKmer((nt, nts...))
 
 """
     Kmer(nts::Vararg{RNA,K}) where {K}
@@ -297,7 +297,7 @@ DNA 5-mer:
 UUAGC
 ```
 """
-@inline Kmer(nts::Vararg{RNA}) = RNAKmer(nts)
+@inline Kmer(nt::RNA, nts::Vararg{RNA}) = RNAKmer((nt, nts...))
 
 """
     Kmer(seq::String)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -4,6 +4,9 @@ global reps = 10
     @test Kmer(DNA_A, DNA_G, DNA_T) === Kmer("AGT")
     @test Kmer(RNA_A, RNA_G, RNA_U) === Kmer("AGU")
     #@test Kmer(AA_R, AA_D, AA_C, AA_B) === Kmer("RDCB")
+
+    @test DNAKmer(DNA_G, DNA_C, DNA_T) == Kmer("GCT")
+    @test RNAKmer(RNA_G, RNA_U, RNA_C, RNA_U) == Kmer("GUCU")
     
     # Check that kmers in strings survive round trip conversion:
     #   String → Kmer → String
@@ -67,6 +70,12 @@ global reps = 10
             @test all(Bool[check_longsequence_construction(Kmer{RNAAlphabet{2},len}, LongRNA{4}(random_rna_kmer(len))) for _ in 1:reps])
             @test all(Bool[check_longsequence_construction(AAKmer{len},              LongAA(random_aa(len)))    for _ in 1:reps])
             
+            # Check Kmer{A1}(::BioSequence{A2}) for compatible A1 and A2
+            @test all(Bool[check_longsequence_construction(Kmer{RNAAlphabet{4}}, LongRNA{2}(random_rna_kmer(len))) for _ in 1:reps])
+            @test all(Bool[check_longsequence_construction(Kmer{RNAAlphabet{2}}, LongDNA{4}(random_dna_kmer(len))) for _ in 1:reps])
+            @test all(Bool[check_longsequence_construction(Kmer{RNAAlphabet{4}}, LongDNA{4}(random_dna_kmer(len))) for _ in 1:reps])
+            @test all(Bool[check_longsequence_construction(Kmer{DNAAlphabet{2}}, LongRNA{4}(random_rna_kmer(len))) for _ in 1:reps])
+
             # BioSequence Construction
             #   Check that kmers can be constructed from a BioSequence
             #   BioSequence → Kmer → BioSequence
@@ -79,7 +88,12 @@ global reps = 10
             @test all(Bool[check_biosequence_construction(Kmer{RNAAlphabet{2},len}, LongSequence{RNAAlphabet{4}}(random_rna_kmer(len))) for _ in 1:reps])
             @test all(Bool[check_biosequence_construction(Kmer{RNAAlphabet{4},len}, LongSequence{RNAAlphabet{2}}(random_rna_kmer(len))) for _ in 1:reps])
             @test all(Bool[check_biosequence_construction(AAKmer{len},              LongSequence{AminoAcidAlphabet}(random_aa(len)))    for _ in 1:reps])
-            
+
+            # Check Kmer(::BioSequence) construction
+            @test all(Bool[check_longsequence_construction(Kmer,                     LongRNA{4}(random_rna_kmer(len))) for _ in 1:reps])
+            @test all(Bool[check_longsequence_construction(Kmer,                     LongDNA{2}(random_dna_kmer(len))) for _ in 1:reps])
+            @test all(Bool[check_longsequence_construction(Kmer,                     LongAA(random_rna_kmer(len))) for _ in 1:reps])
+
             # Construction from element arrays
             #   Check that kmers can be constructed from an array of elements
             #   Vector{T} → Kmer{A,K,N} → Vector{T}


### PR DESCRIPTION
This is a tiny PR based on #25 . Merge / review that first.
This PR resolves an ambiguity error when calling `Kmer()` by turning it into a `MethodError`:
Before:
```
julia> Kmer()
ERROR: MethodError: Kmer() is ambiguous. Candidates:
  Kmer(nts::Vararg{RNA, K}) where K in Kmers at /home/jakni/code/Kmers.jl/src/kmer.jl:294
  Kmer(nts::Vararg{DNA, K}) where K in Kmers at /home/jakni/code/Kmers.jl/src/kmer.jl:276
Possible fix, define
  Kmer()
```
After
```
julia> Kmer()
ERROR: MethodError: no method matching Kmer()
```