### PR TITLE
Add docstrings and update docs

### DIFF
--- a/docs/src/iteration.md
+++ b/docs/src/iteration.md
@@ -15,9 +15,17 @@ This package therefore contains functionality for iterating over all the valid
 
 ```@docs
 EveryKmer
+EveryKmer{T,S}(seq::S, start::Int = firstindex(seq), stop::Int = lastindex(seq)) where {T<:Kmer,S<:BioSequence}
+EveryKmer(seq::BioSequence{A}, ::Val{K}, start = firstindex(seq), stop = lastindex(seq)) where {A,K}
 SpacedKmers
+SpacedKmers{T,S}(seq::S, step::Int, start::Int, stop::Int) where {T<:Kmer,S<:BioSequence}
+SpacedKmers(seq::BioSequence{A}, ::Val{K}, step::Int, start = firstindex(seq), stop = lastindex(seq)) where {A,K}
 EveryCanonicalKmer
+EveryCanonicalKmer{T}(seq::S, start = firstindex(seq), stop = lastindex(seq)) where {T<:Kmer,S<:BioSequence}
+EveryCanonicalKmer(seq::BioSequence{A}, ::Val{K}, start = firstindex(seq), stop = lastindex(seq)) where {A,K}
 SpacedCanonicalKmers
+SpacedCanonicalKmers{T}(seq::S, step::Int, start = firstindex(seq), stop = lastindex(seq)) where {T<:Kmer,S<:BioSequence}
+SpacedCanonicalKmers(seq::BioSequence{A}, ::Val{K}, step::Int, start = firstindex(seq), stop = lastindex(seq)) where {A,K}
 ```
 
 

--- a/docs/src/kmer_types.md
+++ b/docs/src/kmer_types.md
@@ -32,6 +32,9 @@ RNAKmer
 RNA27mer
 RNA31mer
 RNA63mer
+AAKmer
+DNACodon
+RNACodon
 ```
 
 

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -12,22 +12,22 @@ end
 As `BioSequence` concrete subtypes, kmers can be indexed using integers
 
 ```jldoctest
-julia> seq = Kmer(DNA_T, DNA_T, DNA_A, DNA_G, DNA_C)
+julia> kmer = Kmer(DNA_T, DNA_T, DNA_A, DNA_G, DNA_C)
 DNA 5-mer:
 TTAGC
 
-julia> seq[3]
+julia> kmer[3]
 DNA_A
 ```
 
 You can also slice Kmers using UnitRanges:
 
 ```jldoctest
-julia> seq = Kmer(DNA_T, DNA_T, DNA_A, DNA_G, DNA_C)
+julia> kmer = Kmer(DNA_T, DNA_T, DNA_A, DNA_G, DNA_C)
 DNA 5-mer:
 TTAGC
 
-julia> seq[1:3]
+julia> kmer[1:3]
 DNA 3-mer:
 TTA
 ```

--- a/docs/src/translate.md
+++ b/docs/src/translate.md
@@ -56,7 +56,7 @@ Kmers.CodonSet with 2 elements:
 
 ```@docs
 Kmers.CodonSet
-Kmers.ReverseGeneticCoTranslatingde
+Kmers.ReverseGeneticCode
 reverse_translate
 reverse_translate!
 ```

--- a/src/kmer.jl
+++ b/src/kmer.jl
@@ -481,8 +481,8 @@ end
 Create a random kmer of a specified alphabet and length
 
 # Examples
-```jldoctest
-julia> import Random; Random.seed!(1); rand(Kmer{DNAAlphabet{2}, 3})
+```julia
+julia> rand(Kmer{DNAAlphabet{2}, 3})
 BioSymbols.DNA 3-mer:
 ACT
 

--- a/src/kmer.jl
+++ b/src/kmer.jl
@@ -473,6 +473,21 @@ end
     return (head, tail...)
 end
 
+
+"""
+    Base.rand(::Type{Kmer{A,K,N}}) where {A,K,N}
+    Base.rand(::Type{Kmer{A,K}}) where {A,K}
+
+Create a random kmer of a specified alphabet and length
+
+# Examples
+```jldoctest
+julia> import Random; Random.seed!(1); rand(Kmer{DNAAlphabet{2}, 3})
+BioSymbols.DNA 3-mer:
+ACT
+
+```
+"""
 @inline function Base.rand(::Type{Kmer{A,K,N}}) where {A,K,N}
     checkmer(Kmer{A,K,N})
     return Kmer{A,K,N}(rand_kmer_data(Kmer{A,K,N}, BioSequences.iscomplete(A())))

--- a/src/kmer_iteration/EveryCanonicalKmer.jl
+++ b/src/kmer_iteration/EveryCanonicalKmer.jl
@@ -1,4 +1,6 @@
 """
+    EveryCanonicalKmer{T,S}(seq::S, start::Int = firstindex(seq), stop::Int = lastindex(seq)) where {T<:Kmer,S<:BioSequence}
+
 An iterator over every canonical valid overlapping `T<:Kmer` in a given longer 
 `BioSequence`, between a `start` and `stop` position.
 

--- a/src/kmer_iteration/EveryKmer.jl
+++ b/src/kmer_iteration/EveryKmer.jl
@@ -7,6 +7,8 @@
 ### License is MIT: https://github.com/BioJulia/BioSequences.jl/blob/master/LICENSE.md
 
 """
+    EveryKmer{T,S}(seq::S, start::Int = firstindex(seq), stop::Int = lastindex(seq)) where {T<:Kmer,S<:BioSequence}
+
 An iterator over every valid overlapping `T<:Kmer` in a given longer
 `BioSequence` between a `start` and `stop` position. 
 

--- a/src/kmer_iteration/SpacedCanonicalKmers.jl
+++ b/src/kmer_iteration/SpacedCanonicalKmers.jl
@@ -1,5 +1,7 @@
 
 """
+    SpacedCanonicalKmers{T,S}(seq::S, step::Int, start::Int, stop::Int) where {T<:Kmer,S<:BioSequence}
+
 An iterator over every valid `T<:Kmer` separated by a `step` parameter, in a given
 longer `BioSequence`, between a `start` and `stop` position.
 

--- a/src/kmer_iteration/SpacedKmers.jl
+++ b/src/kmer_iteration/SpacedKmers.jl
@@ -1,5 +1,7 @@
 
 """
+    SpacedKmers{T,S}(seq::S, step::Int, start::Int, stop::Int) where {T<:Kmer,S<:BioSequence}
+
 An iterator over every valid `T<:Kmer` separated by a `step` parameter, in a given
 longer `BioSequence`, between a `start` and `stop` position.
 


### PR DESCRIPTION
Hi,

Thanks for developing this package! Just wanted to help update the documentation a bit, both to help clarify some things for myself but also hopefully for others.

- add convenience functions for kmer iterators to docs - currently online docs only show the docstring for the type
- add missing kmer type aliases to online docs
- change variable name in transformation and slicing function example to clarify that the object is a kmer rather than a sequence
- correct typo in `ReverseGeneticCode` `@docs` call for online docs
- add docstring and jldocstest for `base.random(<:Kmer)`
- add primary constructor function calls to docstrings for kmer iterator types