### PR TITLE
Fix iterator constructor and other failing tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 
 [compat]
-BioSequences = "3"
+BioSequences = "3.1.3"
 julia = "1.5"
 
 [extras]

--- a/src/kmer.jl
+++ b/src/kmer.jl
@@ -156,7 +156,8 @@ function Kmer{A,K,N}(itr) where {A,K,N}
     # Construct the head.
     head = zero(UInt64)
     @inbounds for i in 1:n_head
-        sym = convert(eltype(Kmer{A,K,N}), itr[i])
+        (x, next_i) = iterate(itr, i)
+        sym = convert(eltype(Kmer{A,K,N}), x)
         # Encode will throw if it cant encode an element.
         head = (head << bits_per_sym) | UInt64(BioSequences.encode(A(), sym))
     end
@@ -167,7 +168,8 @@ function Kmer{A,K,N}(itr) where {A,K,N}
         Base.@_inline_meta
         body = zero(UInt64)
         @inbounds for i in 1:n_per_chunk
-            sym = convert(eltype(Kmer{A,K,N}), itr[idx[]])
+            (x, next_idx) = iterate(itr, idx[])
+            sym = convert(eltype(Kmer{A,K,N}), x)
             # Encode will throw  if it cant encode an element.
             body = (body << bits_per_sym) | UInt64(BioSequences.encode(A(), sym))
             idx[] += 1

--- a/src/revtrans.jl
+++ b/src/revtrans.jl
@@ -1,5 +1,3 @@
-struct Unsafe end
-
 const N_AA = length(AminoAcidAlphabet())
 
 """

--- a/test/access.jl
+++ b/test/access.jl
@@ -65,7 +65,7 @@
         @test iterate(RNAKmer("ACUG"), 4) == (RNA_G, 5)
         
 
-        @test !isnothing(iterate(RNAKmer("ACUG"), 1))
+        @test iterate(RNAKmer("ACUG"), 1) !== nothing
         @test iterate(RNAKmer("ACUG"), 4)  !== nothing
         @test iterate(RNAKmer("ACUG"), 5)  === nothing
         @test iterate(RNAKmer("ACUG"), -1) === nothing

--- a/test/access.jl
+++ b/test/access.jl
@@ -31,7 +31,8 @@
         @test iterate(DNAKmer("ACTG"), 1)  !== nothing
         @test iterate(DNAKmer("ACTG"), 4)  !== nothing
         @test iterate(DNAKmer("ACTG"), 5)  === nothing
-        @test_throws BoundsError iterate(DNAKmer("ACTG"), -1)
+        @test iterate(DNAKmer("ACTG"), -1) === nothing
+        @test iterate(DNAKmer("ACTG"), 0) === nothing
 
         dna_vec = [DNA_A, DNA_C, DNA_T, DNA_G]
         @test all([nt === dna_vec[i] for (i, nt) in enumerate(dna_kmer)])
@@ -67,7 +68,8 @@
         @test iterate(RNAKmer("ACUG"), 1)  !== nothing
         @test iterate(RNAKmer("ACUG"), 4)  !== nothing
         @test iterate(RNAKmer("ACUG"), 5)  === nothing
-        @test_throws BoundsError iterate(RNAKmer("ACUG"), -1)
+        @test iterate(RNAKmer("ACUG"), -1) === nothing
+        @test iterate(RNAKmer("ACUG"), 0) === nothing
 
         rna_vec = [RNA_A, RNA_C, RNA_U, RNA_G]
         @test all([nt === rna_vec[i] for (i, nt) in enumerate(rna_kmer)])

--- a/test/access.jl
+++ b/test/access.jl
@@ -31,7 +31,7 @@
         @test iterate(DNAKmer("ACTG"), 1)  !== nothing
         @test iterate(DNAKmer("ACTG"), 4)  !== nothing
         @test iterate(DNAKmer("ACTG"), 5)  === nothing
-        @test iterate(DNAKmer("ACTG"), -1) === nothing
+        @test isnothing(iterate(DNAKmer("ACTG"), -1))
         @test iterate(DNAKmer("ACTG"), 0) === nothing
 
         dna_vec = [DNA_A, DNA_C, DNA_T, DNA_G]

--- a/test/access.jl
+++ b/test/access.jl
@@ -65,7 +65,7 @@
         @test iterate(RNAKmer("ACUG"), 4) == (RNA_G, 5)
         
 
-        @test iterate(RNAKmer("ACUG"), 1)  !== nothing
+        @test !isnothing(iterate(RNAKmer("ACUG"), 1))
         @test iterate(RNAKmer("ACUG"), 4)  !== nothing
         @test iterate(RNAKmer("ACUG"), 5)  === nothing
         @test iterate(RNAKmer("ACUG"), -1) === nothing

--- a/test/construction_and_conversion.jl
+++ b/test/construction_and_conversion.jl
@@ -8,6 +8,9 @@ global reps = 10
     @test DNAKmer(DNA_G, DNA_C, DNA_T) == Kmer("GCT")
     @test RNAKmer(RNA_G, RNA_U, RNA_C, RNA_U) == Kmer("GUCU")
     
+    # creation from iterator
+    @test Kmers.kmertype(Kmer{DNAAlphabet{2},31})((i for i in rand(ACGT, 31))) isa Kmers.kmertype(Kmer{DNAAlphabet{2},31})
+    
     # Check that kmers in strings survive round trip conversion:
     #   String → Kmer → String
     function check_string_construction(::Type{T}, seq::AbstractString) where {T<:Kmer}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ include("utils.jl")
 
 if GROUP == "BioSequences" || GROUP == "All"
     include("biosequences_interface.jl")
-    include("conversion.jl")
+    include("construction_and_conversion.jl")
     include("comparisons.jl")
     include("length.jl")
     include("access.jl")


### PR DESCRIPTION
Fixes https://github.com/BioJulia/Kmers.jl/issues/33 but depends on https://github.com/BioJulia/BioSequences.jl/pull/271 in order to pass all tests

```bash
$ julia runtests.jl 
Test Summary:          | Pass  Total
BioSequences Interface |    8      8
Test Summary:                | Pass  Total
Construction and Conversions |  260    260
Test Summary: | Pass  Total
Comparisons   |   86     86
Test Summary: | Pass  Total
Length        |   15     15
Test Summary:         | Pass  Total
Access and Iterations |   57     57
Test Summary: |  Pass  Total
Random        | 12448  12448
Test Summary: | Pass  Total
Find          |   33     33
Test Summary: | Pass  Total
Print         |    5      5
Test Summary: | Pass  Total
Show          |    5      5
Test Summary:   | Pass  Total
Transformations | 3848   3848
Test Summary: | Pass  Total
Mismatches    | 3200   3200
Test Summary: | Pass  Total
Matches       | 3200   3200
Test Summary:       | Pass  Total
De Bruijn Neighbors |    4      4
Test Summary: | Pass  Total
EveryKmer     |   14     14
Test Summary: | Pass  Total
SpacedKmers   |   14     14
Test Summary:      | Pass  Total
EveryCanonicalKmer |   18     18
Test Summary:        | Pass  Total
SpacedCanonicalKmers |   26     26
Test Summary: | Pass  Total
Translation   |   39     39
Test Summary: | Pass  Total
CodonSet      |  241    241
Test Summary:       | Pass  Total
Reverse translation |  148    148
```