### PR TITLE
Add GC counting of 2-bit kmers

### DIFF
--- a/src/Kmers.jl
+++ b/src/Kmers.jl
@@ -119,6 +119,7 @@ include("construction.jl")
 include("indexing.jl")
 include("transformations.jl")
 include("revtrans.jl")
+include("counting.jl")
 
 include("iterators/common.jl")
 include("iterators/FwKmers.jl")

--- a/src/counting.jl
+++ b/src/counting.jl
@@ -1,0 +1,8 @@
+function BioSequences._n_gc(x::Kmer{<:TwoBit})
+    mask = 0x5555555555555555 % UInt
+    n = 0
+    for i in BioSequences.encoded_data(x)
+        n += count_ones((i ⊻ (i >>> 1)) & mask)
+    end
+    return n
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -952,4 +952,18 @@ end
     end
 end
 
+@testset "Counting" begin
+    @testset "Count GC" begin
+        @test count(isGC, mer"TATCGGAGA"d) == 4
+        @test count(isGC, mer"TATATATAAAAA"d) == 0
+        @test count(isGC, mer"AGCGATGCTGATGAGAGAGTCGTGTCGCTGTGATGATGAGGAGCTTAG"d) == 25
+
+        @test count(isGC, mer"AUGUCGUAG"r) == 4
+        @test count(isGC, mer""r) == 0
+        @test count(isGC, mer"AUGUCGGAGAGGAGCGAGAGAGGGCGCGGAUGUAGUGGCUGUAGGAG"r) == 29
+
+        @test_throws MethodError count(isGC, mer"ATATA"a) # amino acid mer
+    end
+end
+
 end # module


### PR DESCRIPTION
More methods should be added, but I need this method now for more work, and I'm sure about the API, which follows BioSequence's new counting API.

