### PR TITLE
WIP: Add Oligomer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.jl.mem
 .DS_Store
 Manifest.toml
+Manifest-v1.*.toml
 TODO.md
 docs/build
 /.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 Manifest.toml
 TODO.md
 docs/build
+/.vscode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,185 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Kmers.jl provides the `Kmer` and `DynamicKmer` types for efficient k-mer representation in bioinformatics. This is a BioJulia package that is tightly coupled to BioSequences.jl and relies heavily on its internals.
+
+**Key Concepts:**
+- **Kmer**: Immutable bitstype sequences of fixed length `K` (compile-time). Stored directly in registers for maximum efficiency. Parameterized as `Kmer{A,K,N}` where `A` is the Alphabet, `K` is the length, and `N` is the number of UInt tuples (derived, not a free parameter).
+- **DynamicKmer**: Similar to Kmer but with runtime length. Slightly less efficient but useful when working with varying k-mer sizes to avoid excessive compilation and type instability.
+
+**Performance Warning:** Kmers are highly optimized for small, fixed-length sequences. Operations that change length (push, pop, slicing) are type unstable unless the compiler can use constant folding. Kmers become inefficient for longer sequences (e.g., reverse-complement of 512-mer takes 16 μs vs 126 ns for LongSequence).
+
+## Development Commands
+
+### Running Tests
+
+```bash
+# Run all tests
+julia --project -e 'using Pkg; Pkg.test()'
+
+# Run tests from REPL
+julia --project
+using Pkg
+Pkg.test()
+
+# Run specific test file
+julia --project test/dynamic.jl
+
+# Run tests with coverage (if needed)
+julia --project --code-coverage test/runtests.jl
+```
+
+### Building Documentation
+
+```bash
+cd docs/
+julia --project -e 'using Pkg; Pkg.instantiate(); include("make.jl")'
+```
+
+### Julia Package Development
+
+```bash
+# Activate the project
+julia --project
+
+# Install dependencies
+using Pkg
+Pkg.instantiate()
+
+# Run the package
+using Kmers
+```
+
+## Architecture
+
+### Core Type System
+
+**Kmer Layout (`struct Kmer{A,K,N}`):**
+- Data stored as `NTuple{N, UInt}`
+- Symbols pack into the **lowest bits** of each UInt, with **first symbols in higher parts**
+- Example: A 16-bit element sequence "A-G" would pack as `(ABC, DEFG)` with 16 unused bits at top
+- Unused bits are always **zero** and always in the **top bits of first UInt**
+- This layout simplifies comparison operators at the cost of more complex construction
+
+**DynamicKmer Layout (`struct DynamicKmer{A,U}`):**
+- Single unsigned integer `x::U` containing both data and length
+- Lower bits store the **length**
+- Upper bits store the **sequence data** (from top to bottom)
+- Example with 2-bit alphabet and UInt8: `TG` is stored as `11 10 00 10` (T G unused length=2)
+
+### RecodingScheme Dispatch
+
+Construction of both Kmer and DynamicKmer uses a `RecodingScheme` pattern to handle different input types efficiently:
+
+- **`Copyable`**: Direct copy from compatible BioSequences (same or compatible alphabet)
+- **`AsciiEncode`**: Efficient ASCII string parsing for DNA/RNA/AA sequences
+- **`TwoToFour`**: Convert 2-bit to 4-bit nucleic acid alphabets
+- **`FourToTwo`**: Convert 4-bit to 2-bit nucleic acid alphabets (errors on ambiguous bases)
+- **`GenericRecoding`**: Fallback for arbitrary iterables
+
+### Source Structure
+
+- **`src/kmer.jl`**: Core Kmer type definition, type checking, basic operations
+- **`src/dynamic.jl`**: DynamicKmer type with runtime length
+- **`src/construction.jl`**: Kmer construction logic and RecodingScheme dispatch
+- **`src/construction_utils.jl`**: Unsafe extraction and shifting utilities for iterators
+- **`src/indexing.jl`**: Indexing operations (scalar, range, logical)
+- **`src/transformations.jl`**: Biological operations (reverse, complement, canonical)
+- **`src/revtrans.jl`**: Reverse translation (amino acid → codons)
+- **`src/counting.jl`**: GC content, symbol counting
+- **`src/tuple_bitflipping.jl`**: Low-level bit manipulation for NTuple operations
+- **`src/iterators/`**: Various kmer iterators (FwKmers, CanonicalKmers, UnambiguousKmers, SpacedKmers)
+
+### Test Structure
+
+Tests are organized by feature:
+- **`test/runtests.jl`**: Main test runner with comprehensive Kmer tests
+- **`test/dynamic.jl`**: DynamicKmer-specific tests (included from runtests.jl)
+- **`test/translation.jl`**: Translation and genetic code tests
+- **`test/benchmark.jl`**: Performance benchmarks
+- **`test/utils.jl`**: Test utilities
+
+## Important Implementation Details
+
+### Type Parameters and Derivation
+
+The `N` parameter in `Kmer{A,K,N}` is **not a free parameter** - it's derived from `A` and `K` using `derive_type`:
+```julia
+derive_type(Kmer{DNAAlphabet{2}, 5})  # Returns Kmer{DNAAlphabet{2}, 5, 1}
+```
+
+When constructing kmers or writing tests, you can omit `N` and it will be derived automatically.
+
+### Alphabet Compatibility
+
+DNA and RNA kmers with the same bit-width (both 2-bit or both 4-bit) are **compatible**:
+- They hash to the same value
+- They can be compared with `==` and `isequal`
+- Construction can convert between them efficiently
+
+However, they are **distinct types** and cannot be directly compared with other BioSequences (this throws an exception).
+
+### Integer Conversion
+
+- `as_integer(kmer)`: Extract coding bits only (no length information)
+- `from_integer(Type, u)`: Reconstruct from integer (for Kmer)
+- `from_integer(Type, u, len)`: Reconstruct from integer with explicit length (for DynamicKmer)
+
+For DynamicKmer, `as_integer` and `from_integer` with different lengths may produce reproducible but incorrect results.
+
+### Unsafe Methods
+
+Several internal functions use the `Unsafe` trait object (`unsafe` singleton) to bypass bounds checking:
+- `unsafe_extract`: Extract kmer from sequence without bounds checking
+- `unsafe_shift_from`: Shift symbols into kmer from sequence
+- These are used internally by iterators for performance
+
+### Writing Tests for New Features
+
+When adding tests, follow the existing patterns:
+1. Group related tests in `@testset` blocks with descriptive names
+2. Test edge cases: empty sequences, length=1, maximum length
+3. Test multiple alphabets where applicable (DNA 2-bit, DNA 4-bit, RNA, AA)
+4. Test different integer widths for DynamicKmer (UInt32, UInt64, UInt128)
+5. Test round-trip conversions (construct → as_integer → from_integer)
+6. For DynamicKmer: test widening and narrowing of backing integer types
+
+## Common Patterns
+
+### Testing Kmer Construction from Various Sources
+
+```julia
+for s in [dna"TAGCTA", rna"UGCUGA", aa"PLKWM"]
+    kmer = Kmer{typeof(Alphabet(s)), length(s)}(s)
+    @test string(kmer) == string(s)
+end
+```
+
+### Testing DynamicKmer Type Conversions
+
+```julia
+# Same alphabet, different backing type
+d32 = DynamicDNAKmer{UInt32}(dna"TAGC")
+d64 = DynamicDNAKmer{UInt64}(d32)
+@test d64 == d32
+
+# Different alphabets (DNA/RNA)
+d_dna = DynamicDNAKmer{UInt64}(dna"ATGT")
+d_rna = DynamicRNAKmer{UInt64}(d_dna)
+@test d_rna == d_dna
+```
+
+## Notes for AI Assistants
+
+1. **BioSequences Integration**: This package depends heavily on BioSequences.jl internals. When in doubt about encoding, check BioSequences documentation.
+
+2. **Type Stability**: Length-changing operations on Kmer are inherently type-unstable. Consider recommending DynamicKmer for variable-length use cases.
+
+3. **Testing Philosophy**: The test suite is comprehensive. New features should have similar test coverage including edge cases, multiple alphabets, and round-trip conversions.
+
+4. **Performance**: Kmers are optimized for small k. For k > ~100, LongSequence may be more appropriate.
+
+5. **Little-Endian Assumption**: Some code (particularly Kmer to DynamicKmer conversion) assumes little-endian architecture. The package won't compile on big-endian systems.

--- a/Project.toml
+++ b/Project.toml
@@ -8,16 +8,17 @@ BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
 
 [weakdeps]
-StringViews = "354b36f9-a18e-4713-926e-db85100087ba"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StringViews = "354b36f9-a18e-4713-926e-db85100087ba"
 
 [extensions]
-StringViewsExt = "StringViews"
 RandomExt = "Random"
+StringViewsExt = "StringViews"
 
 [compat]
-BioSequences = "~3.4.1, 3.5"
+BioSequences = "~3.5.1"
 BioSymbols = "5.1.3"
+BitIntegers = "0.3.5"
 Random = "1.10"
 StableRNGs = "1"
 StringViews = "1"
@@ -25,10 +26,11 @@ Test = "1.10"
 julia = "1.10"
 
 [extras]
+BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StringViews = "354b36f9-a18e-4713-926e-db85100087ba"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 
 [targets]
-test = ["Test", "Random", "StableRNGs", "StringViews"]
+test = ["Test", "Random", "BitIntegers", "StableRNGs", "StringViews"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,14 @@ BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
 
 [weakdeps]
+BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StringViews = "354b36f9-a18e-4713-926e-db85100087ba"
 
 [extensions]
 RandomExt = "Random"
 StringViewsExt = "StringViews"
+BitIntegersExt = "BitIntegers"
 
 [compat]
 BioSequences = "~3.5.1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Kmers"
 uuid = "445028e4-d31f-4f27-89ad-17affd83fc22"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Jakob Nybo Nissen <jakobnybonissen@gmail.com>", "Sabrina Jaye Ward <sabrinajward@protonmail.com>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ BioSymbols = "5.1.3"
 Random = "1.10"
 StableRNGs = "1"
 StringViews = "1"
+Test = "1.10"
 julia = "1.10"
 
 [extras]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,5 +5,8 @@ FASTX = "c2308a5c-f048-11e8-3e8a-31650f418d12"
 Kmers = "445028e4-d31f-4f27-89ad-17affd83fc22"
 MinHash = "4b3c9753-2685-44e9-8a29-365b96c023ed"
 
+[sources]
+Kmers = {path = ".."}
+
 [compat]
 Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,7 @@ makedocs(;
         "Iteration" => "iteration.md",
         "Translation" => "translation.md",
         "Hashing" => "hashing.md",
+        "Dynamic kmers" => "dynamic.md",
         "Random kmers" => "random.md",
         "K-mer replacements" => "replacements.md",
         "FAQ" => "faq.md",

--- a/docs/src/dynamic.md
+++ b/docs/src/dynamic.md
@@ -29,16 +29,22 @@ For example, here is the maximum number of coding bits when using `A = DNAAlphab
 
 The remaining bits are used to store the length of the kmer.
 
+Dynamic kmers can be constructed with the `dmer_str` macro, similar to kmers:
+
+```@docs
+@dmer_str
+```
+
 ### Using dynamically sized kmers
 * Dynamic kmers can be constructed from a normal BioSequence or string, and can then be treated like a normal `BioSequence`.
 
 ```jldoctest
 julia> m = DynamicRNAKmer{UInt32}("AUGUCGA")
-7nt RNA Sequence:
+7nt DynamicRNAKmer{UInt32}:
 AUGUCGA
 
 julia> complement(m)
-7nt RNA Sequence:
+7nt DynamicRNAKmer{UInt32}:
 UACAGCU
 ```
 

--- a/docs/src/dynamic.md
+++ b/docs/src/dynamic.md
@@ -8,25 +8,60 @@ end
 ```
 
 ## Dynamically sized kmers
+
+### Quick Start
+
+```jldoctest
+julia> d = dmer"TAGCAT"d  # Create DNA kmer from string literal
+6nt DynamicDNAKmer{UInt64}:
+TAGCAT
+
+julia> reverse_complement(d)
+6nt DynamicDNAKmer{UInt64}:
+ATGCTA
+
+julia> push(d, DNA_G)  # Returns new instance (immutable)
+7nt DynamicDNAKmer{UInt64}:
+TAGCATG
+```
+
+### Overview
+
 Sometimes, one requires using kmers of differing lengths in the same workload.
 An example could be representing primers, which can be of length 18-24.
 Here, using the `Kmer` type would cause code to specialize on each kmer length.
-Beside causing both excessive compilation and code generation, it will also be slow at runtime, as code using these kmers of mixed length will be type unstable.
+Besides causing both excessive compilation and code generation, it will also be slow at runtime, as code using these kmers of mixed length will be type unstable.
 
 To solve this, Kmers.jl includes the `DynamicKmer` type.
-This type is an immutable, bitstype biosequence, similar to the `Kmer` type, but with the length stored as a run time value.
-
-`DynamicKmer`s are parameterized `DynamicKmer{A <: Alphabet, U <: Unsigned}`, and stores the sequence in a single integer of type `U`. This puts an upper limit on the number elements that can fit in dynamic kmer.
-Because the integer also needs to store its runtime length, computing the maximal number of elements in a given
-concrete `DynamicKmer` is not straightforward.
-It can be obtained with `capacity`.
+This type is an immutable, bitstype biosequence, similar to the `Kmer` type, but with the length stored as a runtime value rather than a compile-time type parameter.
 
 ```@docs
 DynamicKmer
+```
+
+### Basic Properties
+
+`DynamicKmer` has several important characteristics:
+
+- **Immutable**: All operations return new instances. There is no `push!`, only `push`.
+- **Bitstype**: Stored inline in a single unsigned integer.
+- **Runtime length**: Unlike `Kmer`, the length is not part of the type, avoiding type instability for variable-length workloads.
+- **Size limits**: Each `DynamicKmer` type has a maximum capacity determined by its alphabet and backing integer type.
+- **Performance**: Slightly slower than `Kmer` but much faster than `LongSequence` for small sequences.
+
+### Type Parameters
+
+`DynamicKmer{A, U}` is parameterized by `A`, its `Alphabet`, and `U`, the backing unsigned integer type.
+Thus, a `DynamicKmer{DNAAlphabet{4}, UInt32}` is 4 bytes in size, and contains 4-bit DNA.
+
+The backing integer `U` stores both the sequence data and the runtime length.
+This imposes capacity limits. Use `capacity(T)` to determine the maximum number of symbols for a given type.
+
+```@docs
 capacity
 ```
 
-For convenience, the aliases `DynamicDNAKmer`, `DynamicRNAKmer` and `DynamicAAKmer` are provided which alias `DynamicKmer{DNAAlphabet{2}, U} where {U <: Unsigned}`, and similar for `RNAAlphabet{2}` and `AminoAcidAlphabet`.
+For convenience, type aliases are provided:
 
 ```@docs
 DynamicDNAKmer
@@ -34,37 +69,148 @@ DynamicRNAKmer
 DynamicAAKmer
 ```
 
-Dynamic kmers can be constructed with the `dmer_str` macro, similar to kmers:
+### Capacity and Size Limits
+
+The maximum number of symbols depends on both the alphabet and the backing integer type:
+
+| Type | Capacity | Bits per symbol | Notes |
+|------|----------|-----------------|-------|
+| `DynamicDNAKmer{UInt32}` | 14 | 2 | Good for short primers |
+| `DynamicDNAKmer{UInt64}` | 30 | 2 | Standard choice for DNA/RNA |
+| `DynamicRNAKmer{UInt64}` | 30 | 2 | Same capacity as DNA |
+| `DynamicAAKmer{UInt128}` | 15 | 8 | Limited by byte-per-symbol |
+
+Choose a larger backing integer for longer sequences, but be aware that integers larger than 64 bits
+typically become slower the larger they are.
+For very large dynamic kmers, you can use the `BitIntegers.jl` package that provide e.g. `UInt512`,
+but make sure to test that for your application, huge dynamic kmers are still faster than
+`BioSequences.LongSequence`. 
+
+### Construction Methods
+
+Dynamic kmers can be constructed with the `@dmer_str` macro, similar to kmers:
 
 ```@docs
 @dmer_str
 ```
 
-### Using dynamically sized kmers
-Dynamic kmers behave similar to other biosequences.
-Like `LongSequence` and kmers, they can be constructed from strings, bytes and other biosequences.
+Like other `BioSequence`s, they can also be constructed from strings, `AbstractVector{UInt8}`
+(interpreted as containing ASCII), and other `BioSequence`s.
 
 ```jldoctest
-julia> m = DynamicRNAKmer{UInt32}("AUGUCGA")
-7nt DynamicRNAKmer{UInt32}:
-AUGUCGA
+julia> DynamicDNAKmer{UInt64}("TAGCAT")  # From string
+6nt DynamicDNAKmer{UInt64}:
+TAGCAT
 
-julia> complement(m)
-7nt DynamicRNAKmer{UInt32}:
-UACAGCU
+julia> DynamicRNAKmer{UInt64}(rna"AUGCUA")  # From BioSequence
+6nt DynamicRNAKmer{UInt64}:
+AUGCUA
 
-julia> m2 = push(m, DNA_C) # NB: Immutable, so no `push!`
-8nt DynamicRNAKmer{UInt32}:
-AUGUCGAC
+julia> DynamicDNAKmer{UInt64}([DNA_T, DNA_A, DNA_G])  # From iterable
+3nt DynamicDNAKmer{UInt64}:
+TAG
+
+julia> DynamicAAKmer{UInt64}([0x61, 0x63])  # From ASCII AbstractVector{UInt8}
+2aa DynamicAAKmer{UInt64}:
+AC
 ```
 
-### Translating dynamically sized kmers
-Dynamic kmers can be translated to obtain `DynamicAAKmers{U}` with various integer types `U`.
+### Common Operations
+
+Dynamic kmers behave similar to other biosequences, supporting biological transformations, indexing, and length-changing operations.
+
+#### Biological Transformations
+
+```jldoctest
+julia> d = dmer"TAGCAT"d
+6nt DynamicDNAKmer{UInt64}:
+TAGCAT
+
+julia> reverse_complement(d)
+6nt DynamicDNAKmer{UInt64}:
+ATGCTA
+
+julia> canonical(d)
+6nt DynamicDNAKmer{UInt64}:
+ATGCTA
+```
+
+#### Modifying Length
+
+All operations return new instances since `DynamicKmer` is immutable.
+They use e.g. `pop` instead of `pop!`.
+Instead of `popfirst!` and `pushfirst!`, it uses `pop_first` and `push_first`
+(note the underscore):
+
+```jldoctest
+julia> d = dmer"TAG"d
+3nt DynamicDNAKmer{UInt64}:
+TAG
+
+julia> push(d, DNA_C)  # Add to end
+4nt DynamicDNAKmer{UInt64}:
+TAGC
+
+julia> push_first(d, DNA_C)  # Add to beginning
+4nt DynamicDNAKmer{UInt64}:
+CTAG
+```
+
+#### Indexing and Slicing
+Slicing returns a value of the same type. Unlike for `Kmer`, this is type stable.
+Use Base.setindex to create a new kmer with a given `BioSymbol` replaced.
+
+
+```jldoctest
+julia> d = dmer"TAGCAT"d
+6nt DynamicDNAKmer{UInt64}:
+TAGCAT
+
+julia> d[2:4]
+3nt DynamicDNAKmer{UInt64}:
+AGC
+
+julia> Base.setindex(d, 'G', 2)  # Immutable, returns new kmer
+6nt DynamicDNAKmer{UInt64}:
+TGGCAT
+```
+
+#### Integer Conversion
+Like `Kmer`s, `DynamicKmer` can be converted to and from integers.
+Unlike the `Kmer` method, length is required when using `from_integer`:
+
+```@docs
+as_integer(::DynamicKmer)
+from_integer(T::Type{DynamicKmer{A, U}}, x::U, len::Int) where {A <: Alphabet, U <: Unsigned}
+```
+
+### Type Conversions and Compatibility
+
+#### Between Backing Integer Types
+
+Dynamic kmers can be converted between different backing integer types:
+
+```jldoctest
+julia> d32 = DynamicDNAKmer{UInt32}("TAGC")
+4nt DynamicDNAKmer{UInt32}:
+TAGC
+
+julia> d64 = DynamicDNAKmer{UInt64}(d32)  # Widen to larger type
+4nt DynamicDNAKmer{UInt64}:
+TAGC
+
+julia> d64 == d32  # Comparable across backing types
+true
+```
+
+#### Translating Dynamic Kmers
+
+Dynamic kmers can be translated to obtain `DynamicAAKmer{U}` with various integer types `U`.
 The type of `U` is chosen depending on the input type, to ensure that the result will fit in
 the output type.
 
 Note that `DynamicDNAKmer{UInt128}`, and its RNA equivalent, contains too many symbols to fit in
-`DynamicAAKmer{128}`, and therefore these cannot be translated.
+`DynamicAAKmer{UInt128}`, and therefore these cannot be translated (maximum 15 amino acids).
 
 ```@docs
 BioSequences.translate(::DynamicKmer{<:Union{DNAAlphabet, RNAAlphabet}})

--- a/docs/src/dynamic.md
+++ b/docs/src/dynamic.md
@@ -16,18 +16,23 @@ Beside causing both excessive compilation and code generation, it will also be s
 To solve this, Kmers.jl includes the `DynamicKmer` type.
 This type is an immutable, bitstype biosequence, similar to the `Kmer` type, but with the length stored as a run time value.
 
-`DynamicKmer`s are parameterized `DynamicKmer{A <: Alphabet, U <: Unsigned}`, and stores the sequence in a single integer of type `U`. This puts an upper limit on the number of coding bits.
-For example, here is the maximum number of coding bits when using `A = DNAAlphabet{2}`:
+`DynamicKmer`s are parameterized `DynamicKmer{A <: Alphabet, U <: Unsigned}`, and stores the sequence in a single integer of type `U`. This puts an upper limit on the number elements that can fit in dynamic kmer.
+Because the integer also needs to store its runtime length, computing the maximal number of elements in a given
+concrete `DynamicKmer` is not straightforward.
+It can be obtained with `capacity`.
 
-| U       | Available bits  |
-|:--------|:----------------|
-| UInt8   | 6               |
-| UInt16  | 12              |
-| UInt32  | 28              |
-| UInt64  | 58              |
-| UInt128 | 122             |
+```@docs
+DynamicKmer
+capacity
+```
 
-The remaining bits are used to store the length of the kmer.
+For convenience, the aliases `DynamicDNAKmer`, `DynamicRNAKmer` and `DynamicAAKmer` are provided which alias `DynamicKmer{DNAAlphabet{2}, U} where {U <: Unsigned}`, and similar for `RNAAlphabet{2}` and `AminoAcidAlphabet`.
+
+```@docs
+DynamicDNAKmer
+DynamicRNAKmer
+DynamicAAKmer
+```
 
 Dynamic kmers can be constructed with the `dmer_str` macro, similar to kmers:
 
@@ -36,7 +41,8 @@ Dynamic kmers can be constructed with the `dmer_str` macro, similar to kmers:
 ```
 
 ### Using dynamically sized kmers
-* Dynamic kmers can be constructed from a normal BioSequence or string, and can then be treated like a normal `BioSequence`.
+Dynamic kmers behave similar to other biosequences.
+Like `LongSequence` and kmers, they can be constructed from strings, bytes and other biosequences.
 
 ```jldoctest
 julia> m = DynamicRNAKmer{UInt32}("AUGUCGA")
@@ -46,12 +52,20 @@ AUGUCGA
 julia> complement(m)
 7nt DynamicRNAKmer{UInt32}:
 UACAGCU
+
+julia> m2 = push(m, DNA_C) # NB: Immutable, so no `push!`
+8nt DynamicRNAKmer{UInt32}:
+AUGUCGAC
 ```
 
+### Translating dynamically sized kmers
+Dynamic kmers can be translated to obtain `DynamicAAKmers{U}` with various integer types `U`.
+The type of `U` is chosen depending on the input type, to ensure that the result will fit in
+the output type.
+
+Note that `DynamicDNAKmer{UInt128}`, and its RNA equivalent, contains too many symbols to fit in
+`DynamicAAKmer{128}`, and therefore these cannot be translated.
+
 ```@docs
-DynamicKmer
-DynamicDNAKmer
-DynamicRNAKmer
-DynamicAAKmer
-capacity
+BioSequences.translate(::DynamicKmer{<:Union{DNAAlphabet, RNAAlphabet}})
 ```

--- a/docs/src/dynamic.md
+++ b/docs/src/dynamic.md
@@ -209,8 +209,9 @@ Dynamic kmers can be translated to obtain `AAOligomer{U}` with various integer t
 The type of `U` is chosen depending on the input type, to ensure that the result will fit in
 the output type.
 
-Note that `DNAOligomer{UInt128}`, and its RNA equivalent, contains too many symbols to fit in
-`AAOligomer{UInt128}`, and therefore these cannot be translated (maximum 15 amino acids).
+By default, the largest `AAOligomer` type is `AAOligomer{UInt128}`. However, if the package
+BitIntegers.jl is loaded, Kmers.jl will make use of larger integer sizes,
+currently up to `UInt1024`.
 
 ```@docs
 BioSequences.translate(::Oligomer{<:Union{DNAAlphabet, RNAAlphabet}})

--- a/docs/src/dynamic.md
+++ b/docs/src/dynamic.md
@@ -53,4 +53,5 @@ DynamicKmer
 DynamicDNAKmer
 DynamicRNAKmer
 DynamicAAKmer
+capacity
 ```

--- a/docs/src/dynamic.md
+++ b/docs/src/dynamic.md
@@ -1,0 +1,50 @@
+```@meta
+CurrentModule = Kmers
+DocTestSetup = quote
+    using BioSequences
+    using Test
+    using Kmers
+end
+```
+
+## Dynamically sized kmers
+Sometimes, one requires using kmers of differing lengths in the same workload.
+An example could be representing primers, which can be of length 18-24.
+Here, using the `Kmer` type would cause code to specialize on each kmer length.
+Beside causing both excessive compilation and code generation, it will also be slow at runtime, as code using these kmers of mixed length will be type unstable.
+
+To solve this, Kmers.jl includes the `DynamicKmer` type.
+This type is an immutable, bitstype biosequence, similar to the `Kmer` type, but with the length stored as a run time value.
+
+`DynamicKmer`s are parameterized `DynamicKmer{A <: Alphabet, U <: Unsigned}`, and stores the sequence in a single integer of type `U`. This puts an upper limit on the number of coding bits.
+For example, here is the maximum number of coding bits when using `A = DNAAlphabet{2}`:
+
+| U       | Available bits  |
+|:--------|:----------------|
+| UInt8   | 6               |
+| UInt16  | 12              |
+| UInt32  | 28              |
+| UInt64  | 58              |
+| UInt128 | 122             |
+
+The remaining bits are used to store the length of the kmer.
+
+### Using dynamically sized kmers
+* Dynamic kmers can be constructed from a normal BioSequence or string, and can then be treated like a normal `BioSequence`.
+
+```jldoctest
+julia> m = DynamicRNAKmer{UInt32}("AUGUCGA")
+7nt RNA Sequence:
+AUGUCGA
+
+julia> complement(m)
+7nt RNA Sequence:
+UACAGCU
+```
+
+```@docs
+DynamicKmer
+DynamicDNAKmer
+DynamicRNAKmer
+DynamicAAKmer
+```

--- a/ext/BitIntegersExt.jl
+++ b/ext/BitIntegersExt.jl
@@ -1,0 +1,20 @@
+module BitIntegersExt
+
+using BitIntegers
+using Kmers: Kmers
+
+@inline Base.@constprop :aggressive Base.@assume_effects :foldable function Kmers.get_large_bitsize(
+        ::Val{N}
+    ) where {N}
+    if N < 32
+        UInt256
+    elseif N < 64
+        UInt512
+    elseif N < 128
+        UInt1024
+    else
+        error("Kmers does not support BitIntegers larger than UInt1024")
+    end
+end
+
+end # module

--- a/src/Kmers.jl
+++ b/src/Kmers.jl
@@ -28,6 +28,7 @@ export Kmer,
     DynamicDNAKmer,
     DynamicRNAKmer,
     DynamicAAKmer,
+    @dmer_str,
 
     # Immutable operations
     push,

--- a/src/Kmers.jl
+++ b/src/Kmers.jl
@@ -123,8 +123,8 @@ const BitInteger = Union{BitUnsigned, Int8, Int16, Int32, Int64, Int128}
 
 include("tuple_bitflipping.jl")
 include("kmer.jl")
-include("dynamic.jl")
 include("construction.jl")
+include("dynamic.jl")
 include("indexing.jl")
 include("transformations.jl")
 include("revtrans.jl")

--- a/src/Kmers.jl
+++ b/src/Kmers.jl
@@ -20,6 +20,7 @@ export Kmer,
     @mer_str,
     fx_hash,
     derive_type,
+    capacity,
     as_integer,
     from_integer,
 

--- a/src/Kmers.jl
+++ b/src/Kmers.jl
@@ -23,6 +23,12 @@ export Kmer,
     as_integer,
     from_integer,
 
+    # Dynamic
+    DynamicKmer,
+    DynamicDNAKmer,
+    DynamicRNAKmer,
+    DynamicAAKmer,
+
     # Immutable operations
     push,
     push_first,

--- a/src/Kmers.jl
+++ b/src/Kmers.jl
@@ -25,10 +25,10 @@ export Kmer,
     from_integer,
 
     # Dynamic
-    DynamicKmer,
-    DynamicDNAKmer,
-    DynamicRNAKmer,
-    DynamicAAKmer,
+    Oligomer,
+    DNAOligomer,
+    RNAOligomer,
+    AAOligomer,
     @dmer_str,
 
     # Immutable operations

--- a/src/Kmers.jl
+++ b/src/Kmers.jl
@@ -117,6 +117,7 @@ const BitInteger = Union{BitUnsigned, Int8, Int16, Int32, Int64, Int128}
 
 include("tuple_bitflipping.jl")
 include("kmer.jl")
+include("dynamic.jl")
 include("construction.jl")
 include("indexing.jl")
 include("transformations.jl")

--- a/src/construction_utils.jl
+++ b/src/construction_utils.jl
@@ -211,7 +211,7 @@ end
     for i in 0:(S - 1)
         encoding = UInt(BioSequences.extract_encoded_element(seq, from + i))::UInt
         isone(count_ones(encoding)) ||
-            throw_uncertain(Alphabet(kmer), eltype(seq), encoding)
+            throw_uncertain(Alphabet(kmer)::Alphabet, eltype(seq)::Type{<:BioSymbol}, encoding)
         kmer = shift_encoding(kmer, trailing_zeros(encoding) % UInt)
     end
     return kmer

--- a/src/counting.jl
+++ b/src/counting.jl
@@ -6,3 +6,37 @@ function BioSequences._n_gc(x::Kmer{<:TwoBit})
     end
     return n
 end
+
+@inline function BioSequences.count_symbol(x::DynamicKmer, sym::BioSymbol)
+    iszero(BioSequences.bits_per_symbol(x)) && return length(x)
+    u = x.x
+    iszero(u) && return 0
+    U = utype(typeof(x))
+    enc = U(BioSequences.encode(Alphabet(x), sym))
+    mask = coding_mask(x)
+    u = if iszero(enc)
+        u | ~mask
+    else
+        u & mask
+    end
+    return BioSequences.count_encoding(u, enc, BioSequences.BitsPerSymbol(x))
+end
+
+@inline function BioSequences.count_symbol(x::Kmer, sym::BioSymbol)
+    iszero(BioSequences.bits_per_symbol(x)) && return length(x)
+    isempty(x) && return 0
+    enc = UInt64(BioSequences.encode(Alphabet(x), sym))
+    (head, rest...) = x.data
+    mask = get_mask(typeof(x))
+    head = if iszero(enc)
+        head | ~mask
+    else
+        head
+    end
+    BPS = BioSequences.BitsPerSymbol(x)
+    result = BioSequences.count_encoding(head, enc, BPS)
+    for i in rest
+        result += BioSequences.count_encoding(i, enc, BPS)
+    end
+    return result
+end

--- a/src/counting.jl
+++ b/src/counting.jl
@@ -7,7 +7,7 @@ function BioSequences._n_gc(x::Kmer{<:TwoBit})
     return n
 end
 
-@inline function BioSequences.count_symbol(x::DynamicKmer, sym::BioSymbol)
+@inline function BioSequences.count_symbol(x::Oligomer, sym::BioSymbol)
     iszero(BioSequences.bits_per_symbol(x)) && return length(x)
     u = x.x
     iszero(u) && return 0

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -65,15 +65,9 @@ Base.@constprop :aggressive Base.@assume_effects :foldable function max_coding_b
     0
 end
 
-Base.@constprop :aggressive Base.@assume_effects :foldable function length_bits(
-        T::Type{DynamicKmer{A, U}}
-    ) where {A, U}
-    8 * sizeof(U) - max_coding_bits(T)
-end
-
 @inline function length_mask(T::Type{<:DynamicKmer})
     U = BioSequences.encoded_data_eltype(T)
-    return one(U) << length_bits(T) - one(U)
+    return one(U) << (8 * sizeof(U) - max_coding_bits(T)) - one(U)
 end
 
 @inline function top_mask(::Type{U}, len::Integer) where {U <: Unsigned}

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -656,7 +656,7 @@ julia> d == d2 # does not mutate immutable d
 false
 
 julia> push(dmer"RRKRLVD"a, AA_W)
-ERROR: ArgumentError: DynamicKmer is already at max capacity
+ERROR: BoundsError: attempt to access DynamicAAKmer{UInt64} at index [8]
 [...]
 ```
 """
@@ -710,7 +710,7 @@ julia> d == d2 # does not mutate immutable d
 false
 
 julia> push_first(dmer"RRKRLVD"a, AA_W)
-ERROR: ArgumentError: DynamicKmer is already at max capacity
+ERROR: BoundsError: attempt to access DynamicAAKmer{UInt64} at index [8]
 [...]
 ```
 """
@@ -768,7 +768,7 @@ julia> d == d2
 false
 
 julia> pop(dmer""a)
-ERROR: ArgumentError: Cannot pop empty kmer
+ERROR: BoundsError: attempt to access DynamicAAKmer{UInt64} at index [0]
 [...]
 ```
 """
@@ -809,7 +809,7 @@ julia> d == d2
 false
 
 julia> pop_first(dmer""r)
-ERROR: ArgumentError: Cannot pop empty kmer
+ERROR: BoundsError: attempt to access DynamicRNAKmer{UInt64} at index [0]
 [...]
 ```
 """

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -1,5 +1,5 @@
 """
-    DynamicKmer{A <: Alphabet, U <: Unsigned} <: BioSequence{A}
+    Oligomer{A <: Alphabet, U <: Unsigned} <: BioSequence{A}
 
 Dynamic kmers are immutable, bitstype `BioSequence`s similar to `Kmer`s.
 However, unlike the `Kmer` type, the length of a dynamic kmer is a run time
@@ -13,16 +13,16 @@ They are useful when a workload includes kmers of varying sizes, where the
 length specialization of the `Kmer` type would cause excessive compilation
 and/or type instability.
 
-See also: [`DynamicDNAKmer`](@ref), [`Kmer`](@ref)
+See also: [`DNAOligomer`](@ref), [`Kmer`](@ref)
 
 # Examples
 ```jldoctest
-julia> m = DynamicRNAKmer{UInt32}(rna"AUGCUGA")
-7nt DynamicRNAKmer{UInt32}:
+julia> m = RNAOligomer{UInt32}(rna"AUGCUGA")
+7nt RNAOligomer{UInt32}:
 AUGCUGA
 
 julia> reverse_complement(m)
-7nt DynamicRNAKmer{UInt32}:
+7nt RNAOligomer{UInt32}:
 UCAGCAU
 
 julia> DNAKmer{7}(m)
@@ -30,7 +30,7 @@ DNA 7-mer:
 ATGCTGA
 ```
 """
-struct DynamicKmer{A <: Alphabet, U <: Unsigned} <: BioSequence{A}
+struct Oligomer{A <: Alphabet, U <: Unsigned} <: BioSequence{A}
     # Lower L bits: Length
     # Upper bits, from top to bottom: bits
     # E.g. A = 2bit and U = UInt8, TG is stored:
@@ -43,30 +43,30 @@ struct DynamicKmer{A <: Alphabet, U <: Unsigned} <: BioSequence{A}
     end
 end
 
-Base.summary(x::DynamicKmer{<:Union{DNAAlphabet, RNAAlphabet}}) = string(length(x), "nt ", typeof(x))
-Base.summary(x::DynamicKmer{AminoAcidAlphabet}) = string(length(x), "aa ", typeof(x))
-Base.summary(x::DynamicKmer) = string(length(x), "-symbol ", typeof(x))
+Base.summary(x::Oligomer{<:Union{DNAAlphabet, RNAAlphabet}}) = string(length(x), "nt ", typeof(x))
+Base.summary(x::Oligomer{AminoAcidAlphabet}) = string(length(x), "aa ", typeof(x))
+Base.summary(x::Oligomer) = string(length(x), "-symbol ", typeof(x))
 
-function Base.show(io::IO, ::MIME"text/plain", s::DynamicKmer)
+function Base.show(io::IO, ::MIME"text/plain", s::Oligomer)
     println(io, summary(s), ':')
     return print(io, s)
 end
 
-Base.empty(::Type{<:DynamicKmer{A, U}}) where {A, U} = _new_dynamic_kmer(A, zero(U))
+Base.empty(::Type{<:Oligomer{A, U}}) where {A, U} = _new_dynamic_kmer(A, zero(U))
 
-utype(::Type{<:DynamicKmer{A, U}}) where {A, U} = U
+utype(::Type{<:Oligomer{A, U}}) where {A, U} = U
 
-"Alias for DynamicKmer{DNAAlphabet{2}, <:Unsigned}"
-const DynamicDNAKmer{U} = (DynamicKmer{DNAAlphabet{2}, U} where {U <: Unsigned})
+"Alias for Oligomer{DNAAlphabet{2}, <:Unsigned}"
+const DNAOligomer{U} = (Oligomer{DNAAlphabet{2}, U} where {U <: Unsigned})
 
-"Alias for DynamicKmer{RNAAlphabet{2}, <:Unsigned}"
-const DynamicRNAKmer{U} = (DynamicKmer{RNAAlphabet{2}, U} where {U <: Unsigned})
+"Alias for Oligomer{RNAAlphabet{2}, <:Unsigned}"
+const RNAOligomer{U} = (Oligomer{RNAAlphabet{2}, U} where {U <: Unsigned})
 
-"Alias for DynamicKmer{AminoAcidAlphabet, <:Unsigned}"
-const DynamicAAKmer{U} = (DynamicKmer{AminoAcidAlphabet, U} where {U <: Unsigned})
+"Alias for Oligomer{AminoAcidAlphabet, <:Unsigned}"
+const AAOligomer{U} = (Oligomer{AminoAcidAlphabet, U} where {U <: Unsigned})
 
 Base.@constprop :aggressive Base.@assume_effects :foldable function max_coding_bits(
-        ::Type{DynamicKmer{A, U}}
+        ::Type{Oligomer{A, U}}
     ) where {A, U}
     bps = BioSequences.bits_per_symbol(A())
     iszero(bps) && return 0
@@ -79,7 +79,7 @@ Base.@constprop :aggressive Base.@assume_effects :foldable function max_coding_b
     0
 end
 
-@inline function length_mask(T::Type{<:DynamicKmer})
+@inline function length_mask(T::Type{<:Oligomer})
     U = BioSequences.encoded_data_eltype(T)
     return one(U) << (8 * sizeof(U) - max_coding_bits(T)) - one(U)
 end
@@ -88,24 +88,24 @@ end
     return left_shift(typemax(U), (8 * sizeof(U) - len))
 end
 
-@inline function top_mask(T::Type{<:DynamicKmer}, len::Integer)
+@inline function top_mask(T::Type{<:Oligomer}, len::Integer)
     return top_mask(BioSequences.encoded_data_eltype(T), len)
 end
 
-@inline function coding_bits(x::DynamicKmer)
+@inline function coding_bits(x::Oligomer)
     return BioSequences.bits_per_symbol(x) * length(x)
 end
 
-@inline function noncoding_bits(x::DynamicKmer)
+@inline function noncoding_bits(x::Oligomer)
     return 8 * sizeof(x) - coding_bits(x)
 end
 
-@inline function coding_mask(x::DynamicKmer)
+@inline function coding_mask(x::Oligomer)
     return iszero(x.x) ? x.x : top_mask(typeof(x), coding_bits(x))
 end
 
 """
-    capacity(T::Type{<:DynamicKmer{A, U}})::Int
+    capacity(T::Type{<:Oligomer{A, U}})::Int
 
 Compute the maximum number of symbols that an instance of the concrete
 type `T` can contain.
@@ -119,19 +119,19 @@ else the answer is a number in `0:div(8 * sizeof(U), B)`
 
 # Examples
 ```jldoctest
-julia> capacity(DynamicDNAKmer{UInt32})
+julia> capacity(DNAOligomer{UInt32})
 14
 
-julia> capacity(DynamicAAKmer{UInt8})
+julia> capacity(AAOligomer{UInt8})
 0
 
-julia> capacity(DynamicRNAKmer) # NB: UnionAll type
-ERROR: MethodError: no method matching capacity(::Type{DynamicRNAKmer})
+julia> capacity(RNAOligomer) # NB: UnionAll type
+ERROR: MethodError: no method matching capacity(::Type{RNAOligomer})
 [...]
 ```
 """
 Base.@constprop :aggressive Base.@assume_effects :foldable function capacity(
-        T::Type{<:DynamicKmer{A, U}}
+        T::Type{<:Oligomer{A, U}}
     ) where {A, U}
     bps = BioSequences.bits_per_symbol(A())
     return if iszero(bps)
@@ -148,9 +148,9 @@ Base.@constprop :aggressive Base.@assume_effects :foldable function capacity(
     end
 end
 
-BioSequences.encoded_data_eltype(::Type{DynamicKmer{A, U}}) where {A, U} = U
+BioSequences.encoded_data_eltype(::Type{Oligomer{A, U}}) where {A, U} = U
 
-function BioSequences.extract_encoded_element(x::DynamicKmer, i::Integer)
+function BioSequences.extract_encoded_element(x::Oligomer, i::Integer)
     bps = BioSequences.bits_per_symbol(x)
     shift = 8 * sizeof(x) - (i * bps)
     u = right_shift(x.x, shift)
@@ -158,43 +158,43 @@ function BioSequences.extract_encoded_element(x::DynamicKmer, i::Integer)
     return u & mask
 end
 
-Base.length(x::DynamicKmer) = (x.x & length_mask(typeof(x))) % Int
-Base.isempty(x::DynamicKmer) = iszero(x.x)
+Base.length(x::Oligomer) = (x.x & length_mask(typeof(x))) % Int
+Base.isempty(x::Oligomer) = iszero(x.x)
 
-function Kmer{A, K}(x::DynamicKmer{A}) where {A <: Alphabet, K}
+function Kmer{A, K}(x::Oligomer{A}) where {A <: Alphabet, K}
     return @inline derive_type(Kmer{A, K})(x)
 end
 
 # This kmer construction and the one below is efficient, as kmers and dynamic kmers
 # share a very similar encoding scheme.
-function Kmer{A, K, N}(x::DynamicKmer{A}) where {A <: Alphabet, K, N}
+function Kmer{A, K, N}(x::Oligomer{A}) where {A <: Alphabet, K, N}
     check_kmer(Kmer{A, K, N})
-    length(x) == K || error("Must construct kmer from length K DynamicKmer")
+    length(x) == K || error("Must construct kmer from length K Oligomer")
     return from_integer(Kmer{A, K, N}, as_integer(x))
 end
 
 function Kmer{A1, K, N}(
-        x::DynamicKmer{A2}
+        x::Oligomer{A2}
     ) where {M, A1 <: NucleicAcidAlphabet{M}, A2 <: NucleicAcidAlphabet{M}, K, N}
     check_kmer(Kmer{A1, K, N})
-    length(x) == K || error("Must construct kmer from length K DynamicKmer")
+    length(x) == K || error("Must construct kmer from length K Oligomer")
     return from_integer(Kmer{A1, K, N}, as_integer(x))
 end
 
 const HASH_MASK = 0x6ff6e9f0462d5162 % UInt
 
-Base.copy(x::DynamicKmer) = x
-Base.hash(x::DynamicKmer, h::UInt64) = hash(x.x, h ⊻ HASH_MASK) % UInt
-fx_hash(x::DynamicKmer, h::UInt64) = ((bitrotate(h, 5) ⊻ x.x) % UInt) * FX_CONSTANT
+Base.copy(x::Oligomer) = x
+Base.hash(x::Oligomer, h::UInt64) = hash(x.x, h ⊻ HASH_MASK) % UInt
+fx_hash(x::Oligomer, h::UInt64) = ((bitrotate(h, 5) ⊻ x.x) % UInt) * FX_CONSTANT
 
-Base.:(==)(a::DynamicKmer{A, U}, b::DynamicKmer{A, U}) where {A, U} = a === b
+Base.:(==)(a::Oligomer{A, U}, b::Oligomer{A, U}) where {A, U} = a === b
 
 # This is similar to Base.promote, except we use it internally only in this package
 # for dynamic kmers. We use it to compare dynamic kmers with compatible alphabets,
 # which may differ in alphabet or encoded data eltype.
 Base.@constprop :aggressive Base.@assume_effects :foldable function promote_dynamic(
-        a::DynamicKmer{A, U1},
-        b::DynamicKmer{A, U2},
+        a::Oligomer{A, U1},
+        b::Oligomer{A, U2},
     ) where {A <: Alphabet, U1, U2}
     return if U1 == U2
         (a, b)
@@ -211,8 +211,8 @@ end
 
 # Same as above, but complicated by the fact that they do not share alphabet.
 Base.@constprop :aggressive Base.@assume_effects :foldable function promote_dynamic(
-        a::DynamicKmer{<:NucleicAcidAlphabet{N}, U1},
-        b::DynamicKmer{<:NucleicAcidAlphabet{N}, U2}
+        a::Oligomer{<:NucleicAcidAlphabet{N}, U1},
+        b::Oligomer{<:NucleicAcidAlphabet{N}, U2}
     ) where {N, U1, U2}
     return if U1 == U2
         b = _new_dynamic_kmer(typeof(Alphabet(a)), b.x)
@@ -228,27 +228,27 @@ Base.@constprop :aggressive Base.@assume_effects :foldable function promote_dyna
     end
 end
 
-function Base.:(==)(a::DynamicKmer{A, U1}, b::DynamicKmer{A, U2}) where {A, U1, U2}
+function Base.:(==)(a::Oligomer{A, U1}, b::Oligomer{A, U2}) where {A, U1, U2}
     (a, b) = promote_dynamic(a, b)
     return a === b
 end
 
-function Base.:(==)(a::DynamicKmer{<:NucleicAcidAlphabet{N}, U1}, b::DynamicKmer{<:NucleicAcidAlphabet{N}, U2}) where {N, U1, U2}
+function Base.:(==)(a::Oligomer{<:NucleicAcidAlphabet{N}, U1}, b::Oligomer{<:NucleicAcidAlphabet{N}, U2}) where {N, U1, U2}
     (a, b) = promote_dynamic(a, b)
     return a === b
 end
 
-function Base.isless(a::DynamicKmer, b::DynamicKmer)
+function Base.isless(a::Oligomer, b::Oligomer)
     (a, b) = promote_dynamic(a, b)
     return isless(a.x, b.x)
 end
 
-function Base.cmp(a::DynamicKmer, b::DynamicKmer)
+function Base.cmp(a::Oligomer, b::Oligomer)
     (a, b) = promote_dynamic(a, b)
     return cmp(a.x, b.x)
 end
 
-@inline function Base.getindex(x::DynamicKmer{A}, idx::AbstractUnitRange{<:Integer}) where {A}
+@inline function Base.getindex(x::Oligomer{A}, idx::AbstractUnitRange{<:Integer}) where {A}
     isempty(idx) && return empty(typeof(x))
     @boundscheck checkbounds(x, idx)
     bps = BioSequences.bits_per_symbol(x)
@@ -259,68 +259,68 @@ end
     return _new_dynamic_kmer(A, u | (len % U))
 end
 
-function BioSequences.complement(x::DynamicKmer{<:Union{DNAAlphabet{2}, RNAAlphabet{2}}})
+function BioSequences.complement(x::Oligomer{<:Union{DNAAlphabet{2}, RNAAlphabet{2}}})
     A = typeof(Alphabet(x))
     return _new_dynamic_kmer(A, x.x ⊻ coding_mask(x))
 end
 
-function BioSequences.complement(x::DynamicKmer{<:Union{DNAAlphabet{4}, RNAAlphabet{4}}})
+function BioSequences.complement(x::Oligomer{<:Union{DNAAlphabet{4}, RNAAlphabet{4}}})
     A = typeof(Alphabet(x))
     u = BioSequences.complement_bitpar(x.x, A())
     u &= coding_mask(x)
     return _new_dynamic_kmer(A, u | (x.x & length_mask(typeof(x))))
 end
 
-function Base.reverse(x::DynamicKmer{A}) where {A}
+function Base.reverse(x::Oligomer{A}) where {A}
     Bps = BioSequences.BitsPerSymbol(A())
     u = BioSequences.reversebits(x.x, Bps)
     u = left_shift(u, noncoding_bits(x))
     return _new_dynamic_kmer(A, u | (x.x & length_mask(typeof(x))))
 end
 
-function BioSequences.reverse_complement(x::DynamicKmer{<:NucleicAcidAlphabet})
+function BioSequences.reverse_complement(x::Oligomer{<:NucleicAcidAlphabet})
     return reverse(complement(x))
 end
 
-BioSequences.iscanonical(x::DynamicKmer) = x <= reverse_complement(x)
+BioSequences.iscanonical(x::Oligomer) = x <= reverse_complement(x)
 
 # This is more efficient than the fallback because RC'ing is cheap
-function BioSequences.canonical(x::DynamicKmer{<:NucleicAcidAlphabet})
+function BioSequences.canonical(x::Oligomer{<:NucleicAcidAlphabet})
     rc = reverse_complement(x)
     return x < rc ? x : rc
 end
 
-function BioSequences._n_gc(x::DynamicKmer{<:NucleicAcidAlphabet})
+function BioSequences._n_gc(x::Oligomer{<:NucleicAcidAlphabet})
     u = x.x & ~length_mask(typeof(x))
     return BioSequences.gc_bitcount(u, Alphabet(x))
 end
 
 """
-    as_integer(x::DynamicKmer{A, U})::U
+    as_integer(x::Oligomer{A, U})::U
 
 Similar to `as_integer` for kmers, but is guaranteed to return a value of `U`,
 and the number of coding bits is known at runtime.
 """
-function Kmers.as_integer(x::DynamicKmer)
+function Kmers.as_integer(x::Oligomer)
     shift = (8 * sizeof(x) - coding_bits(x))
     return right_shift(x.x, shift)
 end
 
 """
-    from_integer(T::Type{<:DynamicKmer{A, U}}, u::U, len::Int)::T
+    from_integer(T::Type{<:Oligomer{A, U}}, u::U, len::Int)::T
 
-Similar to `from_integer` for `Kmer`, but the length of the resulting `DynamicKmer`
+Similar to `from_integer` for `Kmer`, but the length of the resulting `Oligomer`
 must be passed as an argument. Will error if `len` is larger than the maximal size
 supported by `T`.
 
-If `u` is obtained from a `DynamicKmer` with a length different from `len`,
-the resulting `DynamicKmer` is reproducible, but not correct and may change between
+If `u` is obtained from a `Oligomer` with a length different from `len`,
+the resulting `Oligomer` is reproducible, but not correct and may change between
 versions.
 
 # Examples
 ```jldoctest
-julia> d = DynamicDNAKmer{UInt32}(dna"TAGTGCTGTAGGC")
-13nt DynamicDNAKmer{UInt32}:
+julia> d = DNAOligomer{UInt32}(dna"TAGTGCTGTAGGC")
+13nt DNAOligomer{UInt32}:
 TAGTGCTGTAGGC
 
 julia> u = as_integer(d);
@@ -333,7 +333,7 @@ false
 ```
 """
 function Kmers.from_integer(
-        T::Type{DynamicKmer{A, U}}, x::U, len::Int
+        T::Type{Oligomer{A, U}}, x::U, len::Int
     ) where {A <: Alphabet, U <: Unsigned}
     if (len % UInt) > (capacity(T) % UInt)
         error("Length too large for dynamic kmer")
@@ -345,7 +345,7 @@ function Kmers.from_integer(
 end
 
 ## More construction utils
-function DynamicKmer{T1, U}(x::DynamicKmer{T2, U}) where {
+function Oligomer{T1, U}(x::Oligomer{T2, U}) where {
         B,
         T1 <: NucleicAcidAlphabet{B},
         T2 <: NucleicAcidAlphabet{B},
@@ -354,7 +354,7 @@ function DynamicKmer{T1, U}(x::DynamicKmer{T2, U}) where {
     return _new_dynamic_kmer(T1, x.x)
 end
 
-function DynamicKmer{T1}(x::DynamicKmer{T2}) where {
+function Oligomer{T1}(x::Oligomer{T2}) where {
         B,
         T1 <: NucleicAcidAlphabet{B},
         T2 <: NucleicAcidAlphabet{B},
@@ -363,8 +363,8 @@ function DynamicKmer{T1}(x::DynamicKmer{T2}) where {
 end
 
 # Constructor dispatches to RecodingScheme
-function DynamicKmer{A, U}(x) where {A <: Alphabet, U <: Unsigned}
-    return build_dynamic_kmer(RecodingScheme(A(), typeof(x)), DynamicKmer{A, U}, x)
+function Oligomer{A, U}(x) where {A <: Alphabet, U <: Unsigned}
+    return build_dynamic_kmer(RecodingScheme(A(), typeof(x)), Oligomer{A, U}, x)
 end
 
 # Generic fallback for arbitrary iterables
@@ -450,7 +450,7 @@ end
     return _new_dynamic_kmer(typeof(A), u)
 end
 
-function build_dynamic_kmer(::Copyable, ::Type{T}, x::DynamicKmer) where {T}
+function build_dynamic_kmer(::Copyable, ::Type{T}, x::Oligomer) where {T}
     u = @inline switch_backing_encoding(utype(T), x)
     A = Alphabet(T)
     return _new_dynamic_kmer(typeof(A), u)
@@ -515,7 +515,7 @@ end
 end
 
 # Switch encoding data of `x` to `T`. Error if it doesn't fit.
-function switch_backing_encoding(T::Type{<:Unsigned}, x::DynamicKmer{A, U}) where {A, U}
+function switch_backing_encoding(T::Type{<:Unsigned}, x::Oligomer{A, U}) where {A, U}
     T == U && return x
     return if sizeof(T) < sizeof(x)
         narrow_to(T, x)
@@ -524,10 +524,10 @@ function switch_backing_encoding(T::Type{<:Unsigned}, x::DynamicKmer{A, U}) wher
     end
 end
 
-# Create a DynamicKmer{A, T} containig the same sequence as `x`, efficiently,
+# Create a Oligomer{A, T} containig the same sequence as `x`, efficiently,
 # or error if `x` does not fit in that type.
-function narrow_to(T::Type{<:Unsigned}, x::DynamicKmer{A, U}) where {A, U}
-    newT = DynamicKmer{A, T}
+function narrow_to(T::Type{<:Unsigned}, x::Oligomer{A, U}) where {A, U}
+    newT = Oligomer{A, T}
     if max_coding_bits(newT) < length(x)
         error("Dynamic Kmer do not fit into integer size")
     end
@@ -544,8 +544,8 @@ function narrow_to(T::Type{<:Unsigned}, x::DynamicKmer{A, U}) where {A, U}
     return u % T
 end
 
-# Create a DynamicKmer{A, T} containig the same sequence as `x`, efficiently
-function widen_to(T::Type{<:Unsigned}, x::DynamicKmer{A, U}) where {A, U}
+# Create a Oligomer{A, T} containig the same sequence as `x`, efficiently
+function widen_to(T::Type{<:Unsigned}, x::Oligomer{A, U}) where {A, U}
     # Remove length from encoding
     mask = length_mask(typeof(x))
     u = (x.x & ~mask) % T
@@ -560,7 +560,7 @@ function widen_to(T::Type{<:Unsigned}, x::DynamicKmer{A, U}) where {A, U}
 end
 
 """
-    shift_encoding(x::DynamicKmer{A, U}, encoding::U)::typeof(x)
+    shift_encoding(x::Oligomer{A, U}, encoding::U)::typeof(x)
 
 Add `encoding`, a valid encoding in the alphabet of the `x`,
 and of the same integer type as that used in `x`,
@@ -572,14 +572,14 @@ It is the user's responsibility to ensure that `encoding` is valid.
 ```jldoctest
 julia> enc = UInt32(0x0a); # encoding of DNA_Y in 4-bit alphabets
 
-julia> kmer = DynamicKmer{DNAAlphabet{4}, UInt32}("TAGA");
+julia> kmer = Oligomer{DNAAlphabet{4}, UInt32}("TAGA");
 
 julia> Kmers.shift_encoding(kmer, enc)
-4nt DynamicKmer{DNAAlphabet{4}, UInt32}:
+4nt Oligomer{DNAAlphabet{4}, UInt32}:
 AGAY
 ```
 """
-function shift_encoding(x::DynamicKmer{A, U}, encoding::U) where {A <: Alphabet, U <: Unsigned}
+function shift_encoding(x::Oligomer{A, U}, encoding::U) where {A <: Alphabet, U <: Unsigned}
     mask = length_mask(typeof(x))
     u = x.x & ~mask
     u = left_shift(u, BioSequences.bits_per_symbol(x))
@@ -587,12 +587,12 @@ function shift_encoding(x::DynamicKmer{A, U}, encoding::U) where {A <: Alphabet,
     return _new_dynamic_kmer(A, u | (x.x & mask))
 end
 
-Base.adjoint(x::DynamicKmer) = x
+Base.adjoint(x::Oligomer) = x
 
 """
-    @dmer_str -> DynamicKmer
+    @dmer_str -> Oligomer
 
-Construct a `DynamicKmer{A, UInt64}` from the given string. The macro must be used with a flag
+Construct a `Oligomer{A, UInt64}` from the given string. The macro must be used with a flag
 after the input string, e.g. `d` in `dmer"TAG"d` or `a` in `dmer"PCW"a`, signifying
 the alphabet of the dynamic kmer.
 The flags `d = DNAAlphabet{2}`, `r = RNAAlphabet{2}` and `a = AminoAcidAlphabet`
@@ -601,15 +601,15 @@ are recognized.
 # Examples
 ```jldoctest
 julia> dmer"UGCUA"r
-5nt DynamicRNAKmer{UInt64}:
+5nt RNAOligomer{UInt64}:
 UGCUA
 
 julia> dmer"YDLLKKR"a
-7aa DynamicAAKmer{UInt64}:
+7aa AAOligomer{UInt64}:
 YDLLKKR
 
 julia> dmer"TATTAGCA"d
-8nt DynamicDNAKmer{UInt64}:
+8nt DNAOligomer{UInt64}:
 TATTAGCA
 ```
 """
@@ -618,20 +618,20 @@ macro dmer_str(seq, flag)
     # Unlike @dna_str, we default to 2-bit alphabets, because kmers
     # by convention are usually 2-bit only
     return if flag == "dna" || flag == "d"
-        DynamicDNAKmer{UInt64}(trimmed)
+        DNAOligomer{UInt64}(trimmed)
     elseif flag == "rna" || flag == "r"
-        DynamicRNAKmer{UInt64}(trimmed)
+        RNAOligomer{UInt64}(trimmed)
     elseif flag == "aa" || flag == "a"
-        DynamicAAKmer{UInt64}(trimmed)
+        AAOligomer{UInt64}(trimmed)
     else
         error("Invalid type flag: '$(flag)'")
     end
 end
 
 """
-    push(x::T, s)::T where {T <: DynamicKmer}
+    push(x::T, s)::T where {T <: Oligomer}
 
-Create a new `DynamicKmer` of type `T` by adding the symbol `s` to the end of `x`.
+Create a new `Oligomer` of type `T` by adding the symbol `s` to the end of `x`.
 The argument `s` is converted to the element type of `x` first, so e.g. pushing DNA
 to an RNA kmer may work.
 
@@ -643,22 +643,22 @@ See also: [`push_first`](@ref), [`pop`](@ref), [`pop_first`](@ref)
 # Examples
 ```jldoctest
 julia> d = dmer"TGTGCTGA"d
-8nt DynamicDNAKmer{UInt64}:
+8nt DNAOligomer{UInt64}:
 TGTGCTGA
 
 julia> d2 = push(d, 'G') # converts from Char to DNA
-9nt DynamicDNAKmer{UInt64}:
+9nt DNAOligomer{UInt64}:
 TGTGCTGAG
 
 julia> d == d2 # does not mutate immutable d
 false
 
 julia> push(dmer"RRKRLVD"a, AA_W)
-ERROR: BoundsError: attempt to access DynamicAAKmer{UInt64} at index [8]
+ERROR: BoundsError: attempt to access AAOligomer{UInt64} at index [8]
 [...]
 ```
 """
-function push(x::DynamicKmer{A, U}, s) where {A, U}
+function push(x::Oligomer{A, U}, s) where {A, U}
     T = typeof(x)
 
     # Update new length. Since length is stored in bottom bits,
@@ -683,9 +683,9 @@ end
 @noinline boundserror(x, i) = throw(BoundsError(x, i))
 
 """
-    push_first(x::T, s)::T where {T <: DynamicKmer}
+    push_first(x::T, s)::T where {T <: Oligomer}
 
-Create a new `DynamicKmer` of type `T` by adding the symbol `s` to the start of `x`.
+Create a new `Oligomer` of type `T` by adding the symbol `s` to the start of `x`.
 The argument `s` is converted to the element type of `x` first, so e.g. pushing DNA
 to an RNA kmer may work.
 
@@ -697,22 +697,22 @@ See also: [`push`](@ref), [`pop`](@ref), [`pop_first`](@ref)
 # Examples
 ```jldoctest
 julia> d = dmer"TGTGCTGA"d
-8nt DynamicDNAKmer{UInt64}:
+8nt DNAOligomer{UInt64}:
 TGTGCTGA
 
 julia> d2 = push_first(d, 'G') # converts from Char to DNA
-9nt DynamicDNAKmer{UInt64}:
+9nt DNAOligomer{UInt64}:
 GTGTGCTGA
 
 julia> d == d2 # does not mutate immutable d
 false
 
 julia> push_first(dmer"RRKRLVD"a, AA_W)
-ERROR: BoundsError: attempt to access DynamicAAKmer{UInt64} at index [8]
+ERROR: BoundsError: attempt to access AAOligomer{UInt64} at index [8]
 [...]
 ```
 """
-function push_first(x::DynamicKmer{A, U}, s) where {A, U}
+function push_first(x::Oligomer{A, U}, s) where {A, U}
     T = typeof(x)
 
     # Update new length. Since length is stored in bottom bits,
@@ -745,7 +745,7 @@ function push_first(x::DynamicKmer{A, U}, s) where {A, U}
 end
 
 """
-    pop(x::DynamicKmer{A, U})::DynamicKmer{A, U}
+    pop(x::Oligomer{A, U})::Oligomer{A, U}
 
 Returns a new dynamic kmer with the last symbol of the input `x` removed.
 Throws an `BoundsError` if `x` is empty.
@@ -755,22 +755,22 @@ See also: [`pop_first`](@ref), [`push`](@ref), [`push_first`](@ref)
 # Examples
 ```jldoctest
 julia> d = dmer"EDEAVY"a
-6aa DynamicAAKmer{UInt64}:
+6aa AAOligomer{UInt64}:
 EDEAVY
 
 julia> d2 = pop(d)
-5aa DynamicAAKmer{UInt64}:
+5aa AAOligomer{UInt64}:
 EDEAV
 
 julia> d == d2
 false
 
 julia> pop(dmer""a)
-ERROR: BoundsError: attempt to access DynamicAAKmer{UInt64} at index [0]
+ERROR: BoundsError: attempt to access AAOligomer{UInt64} at index [0]
 [...]
 ```
 """
-function pop(x::DynamicKmer{A, U}) where {A, U}
+function pop(x::Oligomer{A, U}) where {A, U}
     isempty(x) && boundserror(x, 0)
 
     # Decrement length
@@ -786,7 +786,7 @@ function pop(x::DynamicKmer{A, U}) where {A, U}
 end
 
 """
-    pop_first(x::DynamicKmer{A, U})::DynamicKmer{A, U}
+    pop_first(x::Oligomer{A, U})::Oligomer{A, U}
 
 Returns a new dynamic kmer with the first symbol of the input `x` removed.
 Throws an `BoundsError` if `x` is empty.
@@ -796,27 +796,27 @@ See also: [`pop`](@ref), [`push`](@ref), [`push_first`](@ref)
 # Examples
 ```jldoctest
 julia> d = dmer"UGCGUAGCUA"r
-10nt DynamicRNAKmer{UInt64}:
+10nt RNAOligomer{UInt64}:
 UGCGUAGCUA
 
 julia> d2 = pop_first(d)
-9nt DynamicRNAKmer{UInt64}:
+9nt RNAOligomer{UInt64}:
 GCGUAGCUA
 
 julia> d == d2
 false
 
 julia> pop_first(dmer""r)
-ERROR: BoundsError: attempt to access DynamicRNAKmer{UInt64} at index [0]
+ERROR: BoundsError: attempt to access RNAOligomer{UInt64} at index [0]
 [...]
 ```
 """
-function pop_first(x::DynamicKmer{A, U}) where {A, U}
+function pop_first(x::Oligomer{A, U}) where {A, U}
     isempty(x) && boundserror(x, 0)
 
     # Remove length, since we need to shift it to pop first,
     # and shifting would move the length bits
-    mask = length_mask(DynamicKmer{A, U})
+    mask = length_mask(Oligomer{A, U})
     u = x.x & ~mask
 
     # Remove the symbol by shifting
@@ -830,7 +830,7 @@ end
 
 @noinline throw_argumenterror(s::String) = throw(ArgumentError(s))
 
-function Base.setindex(kmer::DynamicKmer{A, U}, v, i::Integer) where {A, U}
+function Base.setindex(kmer::Oligomer{A, U}, v, i::Integer) where {A, U}
     i = Int(i)::Int
     @boundscheck checkbounds(kmer, i)
 
@@ -854,39 +854,39 @@ end
 
 """
     translate(
-        seq::DynamicKmer{<:Union{DNAAlphabet, RNAAlphabet}};
+        seq::Oligomer{<:Union{DNAAlphabet, RNAAlphabet}};
         code::BioSequences.GeneticCode = BioSequences.standard_genetic_code,
         allow_ambiguous_codons::Bool = true,
         alternative_start::Bool = false,
-    )::DynamicAAKmer
+    )::AAOligomer
 
-Translate a nucleotide `DynamicKmer` to a `DynamicAAKmer`.
-The type of the result is the smallest `DynamicAAKmer`, which is statically known to
+Translate a nucleotide `Oligomer` to a `AAOligomer`.
+The type of the result is the smallest `AAOligomer`, which is statically known to
 have a capacity large enough to hold the result.
-If the results cannot be statically guaranteed to fit in a `DynamicAAKmer{UInt128}`,
+If the results cannot be statically guaranteed to fit in a `AAOligomer{UInt128}`,
 throw an exception. Currently, this happens at > 15 amino acids.
 
 The arguments other than `seq` are identical to the method with `LongSequence`.
 
 # Examples
 ```jldoctest
-julia> d = DynamicKmer{DNAAlphabet{4}, UInt64}("TGGCCCGATTGA");
+julia> d = Oligomer{DNAAlphabet{4}, UInt64}("TGGCCCGATTGA");
 
 julia> translate(dmer"TGGCCCGATTGA"d)
-4aa DynamicAAKmer{UInt128}:
+4aa AAOligomer{UInt128}:
 WPD*
 
-julia> translate(DynamicDNAKmer{UInt32}("TGGCCCGATTGA"); alternative_start=true)
-4aa DynamicAAKmer{UInt64}:
+julia> translate(DNAOligomer{UInt32}("TGGCCCGATTGA"); alternative_start=true)
+4aa AAOligomer{UInt64}:
 MPD*
 ```
 """
 function BioSequences.translate(
-        seq::DynamicKmer{<:Union{DNAAlphabet, RNAAlphabet}};
+        seq::Oligomer{<:Union{DNAAlphabet, RNAAlphabet}};
         code::BioSequences.GeneticCode = BioSequences.standard_genetic_code,
         allow_ambiguous_codons::Bool = true,
         alternative_start::Bool = false,
-    )::DynamicAAKmer
+    )::AAOligomer
 
     # Check length of sequence is divisible by 3
     (aalen, remainder) = divrem(length(seq) % UInt, 3 % UInt)
@@ -919,7 +919,7 @@ function BioSequences.translate(
 end
 
 @inline function inbounds_aa_from(
-        seq::DynamicKmer{<:Union{DNAAlphabet{2}, RNAAlphabet{2}}},
+        seq::Oligomer{<:Union{DNAAlphabet{2}, RNAAlphabet{2}}},
         code::BioSequences.GeneticCode,
         i::Int,
         _::Bool,
@@ -932,7 +932,7 @@ end
 end
 
 @inline function inbounds_aa_from(
-        seq::DynamicKmer{<:Union{DNAAlphabet{4}, RNAAlphabet{4}}},
+        seq::Oligomer{<:Union{DNAAlphabet{4}, RNAAlphabet{4}}},
         code::BioSequences.GeneticCode,
         i::Int,
         allow_ambiguous_codons::Bool,
@@ -950,7 +950,7 @@ end
 end
 
 @inline Base.@constprop :aggressive Base.@assume_effects :foldable function get_matching_aaseq_utype(
-        T::Type{<:DynamicKmer{<:NucleicAcidAlphabet}}
+        T::Type{<:Oligomer{<:NucleicAcidAlphabet}}
     )
     max_aa = div(capacity(T) % UInt, UInt(3)) % Int
     if max_aa < 2
@@ -962,6 +962,6 @@ end
     elseif max_aa < 16
         UInt128
     else
-        error("Cannot fit resulting AA sequence in a DynamicAAKmer{UInt128}")
+        error("Cannot fit resulting AA sequence in a AAOligomer{UInt128}")
     end
 end

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -246,10 +246,10 @@ function build_dynamic_kmer(::RecodingScheme, ::Type{T}, x) where {T}
         len += 1
         shift -= bps
         len > cap && error("Iterator size exceeds maximum capacity of dynamic kmer")
-        enc = BioSequences.encode(A, i) % U
+        enc = BioSequences.encode(A, convert(eltype(T), i)) % U
         u |= left_shift(enc, shift)
     end
-    return _new_dynamic_kmer(A, (len % U) | u)
+    return _new_dynamic_kmer(typeof(A), (len % U) | u)
 end
 
 # Here, we can extract the encoding directly

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -299,7 +299,7 @@ function DynamicKmer{T1}(x::DynamicKmer{T2}) where {
     return _new_dynamic_kmer(T1, x.x)
 end
 
-# Constructor dispatchtes to RecodingScheme
+# Constructor dispatches to RecodingScheme
 function DynamicKmer{A, U}(x) where {A <: Alphabet, U <: Unsigned}
     return build_dynamic_kmer(RecodingScheme(A(), typeof(x)), DynamicKmer{A, U}, x)
 end
@@ -355,9 +355,9 @@ function build_dynamic_kmer(::Copyable, ::Type{T}, x::Kmer) where {T}
 end
 
 function build_dynamic_kmer(::Copyable, ::Type{T}, x::DynamicKmer) where {T}
-    d = @inline switch_backing(utype(T), x)
+    u = @inline switch_backing_encoding(utype(T), x)
     A = Alphabet(T)
-    return _new_dynamic_kmer(typeof(A), d.x)
+    return _new_dynamic_kmer(typeof(A), u)
 end
 
 @inline function build_dynamic_kmer(
@@ -488,7 +488,6 @@ function shift_encoding(x::DynamicKmer{A, U}, encoding::U) where {A <: Alphabet,
     u = x.x & ~mask
     u = left_shift(u, BioSequences.bits_per_symbol(x))
     u |= left_shift(encoding, noncoding_bits(x))
-    u | (x.x & mask)
     return _new_dynamic_kmer(A, u | (x.x & mask))
 end
 

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -110,18 +110,6 @@ end
 
 Base.length(x::DynamicKmer) = (x.x & length_mask(typeof(x))) % Int
 
-function DynamicKmer{A, U}(kmer::Kmer{A}) where {A <: Alphabet, U <: Unsigned}
-    T = DynamicKmer{A, U}
-    K = length(kmer)
-    if capacity(T) < K
-        error("Kmer size exceeds maximum size of dynamic kmer")
-    end
-    u = as_integer(kmer) % U
-    bps = BioSequences.bits_per_symbol(A())
-    shift = 8 * sizeof(T) - (K * bps)
-    return _new_dynamic_kmer(A, left_shift(u, shift) | (K % U))
-end
-
 function Kmer{A, K}(x::DynamicKmer{A}) where {A <: Alphabet, K}
     return @inline derive_type(Kmer{A, K})(x)
 end
@@ -154,7 +142,7 @@ const HASH_MASK = 0x6ff6e9f0462d5162 % UInt
 
 Base.copy(x::DynamicKmer) = x
 Base.hash(x::DynamicKmer, h::UInt64) = hash(x.x, h ⊻ HASH_MASK)
-fx_hash(x::DynamicKmer, u::UInt64) = (bitrotate(h, 5) ⊻ x.x) * FX_CONSTANT
+fx_hash(x::DynamicKmer, h::UInt64) = (bitrotate(h, 5) ⊻ x.x) * FX_CONSTANT
 Base.:(==)(a::DynamicKmer, b::DynamicKmer) = a.x == b.x
 Base.isless(a::DynamicKmer{A}, b::DynamicKmer{A}) where {A} = isless(a.x, b.x)
 Base.cmp(a::DynamicKmer{A}, b::DynamicKmer{A}) where {A} = cmp(a.x, b.x)

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -443,10 +443,7 @@ end
 
     # Kmers keep thier coding bits in the lowest part of the data,
     # and dynamic kmers in the upper.
-    # Also, the requested type U may be much bigger than the kmer's tuple,
-    # which requires further shift
-    shift = 8 * sizeof(U) - len * bps
-    u = left_shift(u, shift)
+    u = left_shift(u, bits_unused(typeof(x)))
 
     # Add in length
     u |= len % U

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -1,0 +1,180 @@
+struct DynamicKmer{A <: Alphabet, U <: Unsigned} <: BioSequence{A}
+    # Lower L bits: Length
+    # Upper bits, from top to bottom: bits
+    # E.g. A = 2bit and U = UInt8, TG is stored:
+    #  11 10 00                    10
+    #  T  G  unused (always zero)  length
+
+    x::U
+
+    global function _new_dynamic_kmer(::Type{A}, x::U) where {A, U}
+        return new{A, U}(x)
+    end
+end
+
+const DynamicDNAKmer{U} = DynamicKmer{DNAAlphabet{2}, U}
+const DynamicRNAKmer{U} = DynamicKmer{RNAAlphabet{2}, U}
+const DynamicAAKmer{U} = DynamicKmer{AminoAcidAlphabet, U}
+
+Base.@constprop :aggressive Base.@assume_effects :foldable function max_coding_bits(
+        ::Type{DynamicKmer{A, U}}
+    ) where {A, U}
+    bps = BioSequences.bits_per_symbol(A())
+    iszero(bps) && return 0
+    B = 8 * sizeof(U)
+    for S in div(B, bps):-1:0
+        Lb = 64 - leading_zeros(S)
+        Sb = bps * S
+        Lb + Sb ≤ B && return Sb
+    end
+    0
+end
+
+Base.@constprop :aggressive Base.@assume_effects :foldable function length_bits(
+        T::Type{DynamicKmer{A, U}}
+    ) where {A, U}
+    8 * sizeof(U) - max_coding_bits(T)
+end
+
+@inline function length_mask(T::Type{<:DynamicKmer})
+    U = BioSequences.encoded_data_eltype(T)
+    return one(U) << length_bits(T) - one(U)
+end
+
+@inline function top_mask(::Type{U}, len::Integer) where {U <: Unsigned}
+    return left_shift(typemax(U), (8 * sizeof(U) - len))
+end
+
+@inline function top_mask(T::Type{<:DynamicKmer}, len::Integer)
+    return top_mask(BioSequences.encoded_data_eltype(T), len)
+end
+
+@inline function coding_bits(x::DynamicKmer)
+    return BioSequences.bits_per_symbol(x) * length(x)
+end
+
+@inline function noncoding_bits(x::DynamicKmer)
+    return 8 * sizeof(x) - coding_bits(x)
+end
+
+@inline function coding_mask(x::DynamicKmer)
+    return top_mask(typeof(x), coding_bits(x))
+end
+
+capacity(T::Type{<:DynamicKmer}) = div(max_coding_bits(T), BioSequences.bits_per_symbol(Alphabet(T)))
+
+BioSequences.encoded_data_eltype(::Type{DynamicKmer{A, U}}) where {A, U} = U
+
+function BioSequences.extract_encoded_element(x::DynamicKmer, i::Integer)
+    bps = BioSequences.bits_per_symbol(x)
+    shift = 8 * sizeof(x) - (i * bps)
+    u = right_shift(x.x, shift)
+    mask = one(x.x) << (bps) - one(x.x)
+    return u & mask
+end
+
+Base.length(x::DynamicKmer) = (x.x & length_mask(typeof(x))) % Int
+
+function DynamicKmer{A, U}(itr) where {A <: Alphabet, U <: Unsigned}
+    T = DynamicKmer{A, U}
+    bps = BioSequences.bits_per_symbol(T)
+    shift = 8 * sizeof(T)
+    u = zero(U)
+    cap = capacity(T)
+    len = 0
+    for i in itr
+        len += 1
+        shift -= bps
+        len > cap && error("Iterator size exceeds maximum capacity of dynamic kmer")
+        enc = BioSequences.encode(A(), i) % U
+        u |= left_shift(enc, shift)
+    end
+    return _new_dynamic_kmer(A, (len % U) | u)
+end
+
+function DynamicKmer{A, U}(kmer::Kmer{A}) where {A <: Alphabet, U <: Unsigned}
+    T = DynamicKmer{A, U}
+    K = length(kmer)
+    if capacity(T) < K
+        error("Kmer size exceeds maximum size of dynamic kmer")
+    end
+    u = as_integer(kmer) % U
+    bps = BioSequences.bits_per_symbol(A())
+    shift = 8 * sizeof(T) - (K * bps)
+    return _new_dynamic_kmer(A, left_shift(u, shift) | (K % U))
+end
+
+function Kmer{A, K}(x::DynamicKmer{A}) where {A <: Alphabet, K}
+    return derive_type(Kmer{A, K})(x)
+end
+
+@assert UInt == UInt64
+
+function Kmer{A, K, N}(x::DynamicKmer) where {A <: Alphabet, K, N}
+    length(x) == K || error("Must construct kmer from length K DynamicKmer")
+    # This is now a compile time constant
+    noncoding = 8 * sizeof(x) - BioSequences.bits_per_symbol(x) * K
+    return if N == 0
+        Kmer{A, K, N}(unsafe, ())
+    elseif N == 1
+        u = right_shift(x.x % UInt64, noncoding)
+        Kmer{A, K, N}(unsafe, (u,))
+    elseif N == 2
+        u = right_shift(x.x, noncoding)
+        t1 = (u >> 64) % UInt64
+        t2 = u % UInt64
+        Kmer{A, K, N}(unsafe, (t1, t2))
+    else
+        error("Unreachable")
+    end
+end
+
+const HASH_MASK = 0x6ff6e9f0462d5162 % UInt
+
+Base.hash(x::DynamicKmer, h::UInt64) = hash(x.x, h ⊻ HASH_MASK)
+Base.:(==)(a::DynamicKmer, b::DynamicKmer) = a.x == b.x
+Base.isless(a::DynamicKmer{A}, b::DynamicKmer{A}) where {A} = isless(a.x, b.x)
+Base.cmp(a::DynamicKmer{A}, b::DynamicKmer{A}) where {A} = cmp(a.x, b.x)
+
+@inline function Base.getindex(x::DynamicKmer{A}, idx::AbstractUnitRange{<:Integer}) where {A}
+    @boundscheck checkbounds(x, idx)
+    bps = BioSequences.bits_per_symbol(x)
+    len = length(idx)
+    u = left_shift(x.x, (first(idx) - 1) * bps)
+    U = BioSequences.encoded_data_eltype(typeof(x))
+    u &= top_mask(U, len * bps)
+    return _new_dynamic_kmer(A, u | (len % U))
+end
+
+function BioSequences.complement(x::DynamicKmer{<:Union{DNAAlphabet{2}, RNAAlphabet{2}}})
+    A = typeof(Alphabet(x))
+    return _new_dynamic_kmer(A, x.x ⊻ coding_mask(x))
+end
+
+function BioSequences.complement(x::DynamicKmer{<:Union{DNAAlphabet{4}, RNAAlphabet{4}}})
+    A = typeof(Alphabet(x))
+    u = BioSequences.complement_bitpar(x.x, A())
+    u &= coding_mask(x)
+    return _new_dynamic_kmer(A, u | (x.x & length_mask(typeof(x))))
+end
+
+function Base.reverse(x::DynamicKmer{A}) where {A}
+    Bps = BioSequences.BitsPerSymbol(A())
+    u = BioSequences.reversebits(x.x, Bps)
+    u = left_shift(u, noncoding_bits(x))
+    return _new_dynamic_kmer(A, u | (x.x & length_mask(typeof(x))))
+end
+
+function BioSequences.reverse_complement(x::DynamicKmer{<:NucleicAcidAlphabet})
+    return reverse(complement(x))
+end
+
+BioSequences.iscanonical(x::DynamicKmer) = x <= reverse_complement(x)
+
+# _n_gc
+
+# Counting
+
+# Construction utils!!!
+
+# As integer, from integer. Should we guarantee the encoding scheme?

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -492,3 +492,42 @@ function shift_encoding(x::DynamicKmer{A, U}, encoding::U) where {A <: Alphabet,
 end
 
 Base.adjoint(x::DynamicKmer) = x
+
+"""
+    @dmer_str -> DynamicKmer
+
+Construct a `DynamicKmer{A, UInt64}` from the given string. The macro must be used with a flag
+after the input string, e.g. `d` in `dmer"TAG"d` or `a` in `dmer"PCW"a`, signifying
+the alphabet of the dynamic kmer.
+The flags `d = DNAAlphabet{2}`, `r = RNAAlphabet{2}` and `a = AminoAcidAlphabet`
+are recognized.
+
+# Examples
+```jldoctest
+julia> dmer"UGCUA"r
+5nt DynamicRNAKmer{UInt64}:
+UGCUA
+
+julia> dmer"YDLLKKR"a
+7aa DynamicAAKmer{UInt64}:
+YDLLKKR
+
+julia> dmer"TATTAGCA"d
+8nt DynamicDNAKmer{UInt64}
+TATTAGCA
+```
+"""
+macro dmer_str(seq, flag)
+    trimmed = BioSequences.remove_newlines(seq)
+    # Unlike @dna_str, we default to 2-bit alphabets, because kmers
+    # by convention are usually 2-bit only
+    return if flag == "dna" || flag == "d"
+        DynamicDNAKmer{UInt64}(trimmed)
+    elseif flag == "rna" || flag == "r"
+        DynamicRNAKmer{UInt64}(trimmed)
+    elseif flag == "aa" || flag == "a"
+        DynamicAAKmer{UInt64}(trimmed)
+    else
+        error("Invalid type flag: '$(flag)'")
+    end
+end

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -438,6 +438,7 @@ end
             u |= left_shift(i % U, shift)
             shift -= 64
         end
+        u
     end
 
     # Kmers keep thier coding bits in the lowest part of the data,

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -38,6 +38,15 @@ struct DynamicKmer{A <: Alphabet, U <: Unsigned} <: BioSequence{A}
     end
 end
 
+Base.summary(x::DynamicKmer{<:Union{DNAAlphabet, RNAAlphabet}}) = string(length(x), "nt ",  typeof(x))
+Base.summary(x::DynamicKmer{AminoAcidAlphabet}) = string(length(x), "aa ",  typeof(x))
+Base.summary(x::DynamicKmer) = string(length(x), "-symbol ",  typeof(x))
+
+function Base.show(io::IO, ::MIME"text/plain", s::DynamicKmer)
+    println(io, summary(s), ':')
+    return print(io, s)
+end
+
 Base.empty(::Type{<:DynamicKmer{A, U}}) where {A, U} = _new_dynamic_kmer(A, zero(U))
 
 utype(::Type{<:DynamicKmer{A, U}}) where {A, U} = U

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -239,6 +239,12 @@ end
 
 BioSequences.iscanonical(x::DynamicKmer) = x <= reverse_complement(x)
 
+# This is more efficient than the fallback because RC'ing is cheap
+function BioSequences.canonical(x::DynamicKmer{<:NucleicAcidAlphabet})
+    rc = reverse_complement(x)
+    return x < rc ? x : rc
+end
+
 function BioSequences._n_gc(x::DynamicKmer{<:NucleicAcidAlphabet})
     u = x.x & ~length_mask(typeof(x))
     return BioSequences.gc_bitcount(u, Alphabet(x))

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -353,5 +353,5 @@ function shift_encoding(x::DynamicKmer{A, U}, encoding::U) where {A <: Alphabet,
     u = left_shift(u, BioSequences.bits_per_symbol(x))
     u |= left_shift(encoding, noncoding_bits(x))
     u | (x.x & mask)
-    _new_dynamic_kmer(A, u | (x.x & mask))
+    return _new_dynamic_kmer(A, u | (x.x & mask))
 end

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -75,6 +75,7 @@ end
 @inline function Base.setindex(kmer::Kmer, i::Integer, s)
     @boundscheck checkbounds(kmer, i)
     bps = BioSequences.bits_per_symbol(kmer)
+    iszero(bps) && return kmer
     symbol = convert(eltype(kmer), s)
     encoding = UInt(BioSequences.encode(Alphabet(kmer), symbol))
     (i, o) = BioSequences.bitindex(kmer, i % UInt)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -72,7 +72,7 @@ end
     return i + 1, o
 end
 
-@inline function Base.setindex(kmer::Kmer, i::Integer, s)
+@inline function Base.setindex(kmer::Kmer, s, i::Integer)
     @boundscheck checkbounds(kmer, i)
     bps = BioSequences.bits_per_symbol(kmer)
     iszero(bps) && return kmer

--- a/src/kmer.jl
+++ b/src/kmer.jl
@@ -118,11 +118,11 @@ end
 @inline nsize(::Type{<:Kmer{A, K, N}}) where {A, K, N} = N
 
 @inline function n_unused(::Type{<:Kmer{A, K, N}}) where {A, K, N}
-    per_word_capacity(Kmer{A, K, N}) * N - K
+    return per_word_capacity(Kmer{A, K, N}) * N - K
 end
 
 @inline function bits_unused(T::Type{<:Kmer})
-    n_unused(T) * BioSequences.bits_per_symbol(Alphabet(T))
+    return n_unused(T) * BioSequences.bits_per_symbol(Alphabet(T))
 end
 
 @inline function n_coding_elements(::Type{<:Kmer{A, K}}) where {A, K}

--- a/src/kmer.jl
+++ b/src/kmer.jl
@@ -116,9 +116,14 @@ end
 
 @inline ksize(::Type{<:Kmer{A, K}}) where {A, K} = K
 @inline nsize(::Type{<:Kmer{A, K, N}}) where {A, K, N} = N
-@inline n_unused(::Type{<:Kmer{A, K, N}}) where {A, K, N} = capacity(Kmer{A, K, N}) - K
-@inline bits_unused(T::Type{<:Kmer}) =
+
+@inline function n_unused(::Type{<:Kmer{A, K, N}}) where {A, K, N}
+    per_word_capacity(Kmer{A, K, N}) * N - K
+end
+
+@inline function bits_unused(T::Type{<:Kmer})
     n_unused(T) * BioSequences.bits_per_symbol(Alphabet(T))
+end
 
 @inline function n_coding_elements(::Type{<:Kmer{A, K}}) where {A, K}
     return cld(BioSequences.bits_per_symbol(A()) * K, 8 * sizeof(UInt))
@@ -126,10 +131,6 @@ end
 
 @inline function per_word_capacity(::Type{<:Kmer{A}}) where {A}
     return div(8 * sizeof(UInt), BioSequences.bits_per_symbol(A()))
-end
-
-@inline function capacity(::Type{<:Kmer{A, K, N}}) where {A, K, N}
-    return per_word_capacity(Kmer{A, K, N}) * N
 end
 
 @inline function elements_in_head(::Type{<:Kmer{A, K, N}}) where {A, K, N}

--- a/src/kmer.jl
+++ b/src/kmer.jl
@@ -205,10 +205,6 @@ Base.:(==)(x::BioSequence, y::Kmer) = throw(MethodError(==, (x, y)))
 
 Base.hash(x::Kmer, h::UInt) = hash(x.data, h ⊻ ksize(typeof(x)))
 
-if Sys.WORD_SIZE != 64
-    error("Kmer.jl only supports 64-bit systems")
-end
-
 # These constants are from the original implementation
 @static if Sys.WORD_SIZE == 32
     # typemax(UInt32) / golden ratio

--- a/src/kmer.jl
+++ b/src/kmer.jl
@@ -359,7 +359,7 @@ function from_integer end
     return from_integer(derive_type(T), u)
 end
 
-@inline function from_integer(T::Type{<:Kmer{A, K, N}}, u::BitUnsigned) where {A, K, N}
+@inline function from_integer(T::Type{<:Kmer{A, K, N}}, u::Unsigned) where {A, K, N}
     check_kmer(T)
     bits = K * BioSequences.bits_per_symbol(A())
     iszero(bits) && return zero_kmer(T)

--- a/src/tuple_bitflipping.jl
+++ b/src/tuple_bitflipping.jl
@@ -22,7 +22,7 @@ end
 # the `carry` argument to the right side of the resulting tuple.
 # Returns (new_carry, new_tuple)
 @inline function leftshift_carry(
-        x::Tuple{Vararg{T}},
+        x::Tuple{T, Vararg{T}},
         nbits::Integer,
         carry::T,
     ) where {T <: Unsigned}
@@ -33,7 +33,7 @@ end
 end
 
 @inline function rightshift_carry(
-        x::Tuple{Vararg{T}},
+        x::Tuple{T, Vararg{T}},
         nbits::Integer,
         carry::T,
     ) where {T <: Unsigned}

--- a/test/dynamic.jl
+++ b/test/dynamic.jl
@@ -23,10 +23,10 @@ using BioSequences
 
     # Two to four alphabet
     for s in Any[
-        dna"ATGCTGTGACCA",
-        dna"ATGTCGA",
-        dna"",
-    ]
+            dna"ATGCTGTGACCA",
+            dna"ATGTCGA",
+            dna"",
+        ]
         for A in Any[DNAAlphabet, RNAAlphabet]
             for (srcB, dstB) in [(2, 4), (4, 2)]
                 src = LongSequence{A{srcB}}(s)

--- a/test/dynamic.jl
+++ b/test/dynamic.jl
@@ -3,43 +3,255 @@ using Kmers
 using BioSequences
 
 @testset "Construction" begin
-    for s in [
-            dna"ATGTCGTTAGT",
-            dna"",
-            dna"YATGC-ATGwTCTDV",
-            rna"AUGUCGAGUGUAUGC",
-            rna"AUGCWSYGANN--CA",
-            aa"KWOP",
-            aa"",
-            aa"TYAPC",
-
-        ]
-        for i in (s, string(s), (i for i in s))
-            m = DynamicKmer{typeof(Alphabet(s)), UInt64}(i)
-            @test length(m) == length(i)
-            @test m == s
+    @testset "Same alphabet, and ASCII alphabet" begin
+        for s in [
+                dna"ATGTCGTTAGT",
+                dna"",
+                dna"YATGC-ATGwTCTDV",
+                rna"AUGUCGAGUGUAUGC",
+                rna"AUGCWSYGANN--CA",
+                aa"KWOP",
+                aa"",
+                aa"TYAPC",
+            ]
+            for i in (s, string(s), (i for i in s))
+                m = DynamicKmer{typeof(Alphabet(s)), UInt64}(i)
+                @test length(m) == length(i)
+                @test m == s
+            end
         end
     end
 
-    # Two to four alphabet
-    for s in Any[
-            dna"ATGCTGTGACCA",
-            dna"ATGTCGA",
-            dna"",
-        ]
-        for A in Any[DNAAlphabet, RNAAlphabet]
-            for (srcB, dstB) in [(2, 4), (4, 2)]
-                src = LongSequence{A{srcB}}(s)
-                dst = DynamicKmer{A{dstB}, UInt64}(src)
+    @testset "Two to four bit alphabet" begin
+        for s in Any[
+                dna"ATGCTGTGACCA",
+                dna"ATGTCGA",
+                dna"",
+            ]
+            for A in Any[DNAAlphabet, RNAAlphabet]
+                for (srcB, dstB) in [(2, 4), (4, 2)]
+                    src = LongSequence{A{srcB}}(s)
+                    dst = DynamicKmer{A{dstB}, UInt64}(src)
 
-                @test src == dst
+                    @test src == dst
+                end
             end
+        end
+    end
+
+    @testset "Four to two bit alphabet" begin
+        for s in [dna"TAGCTGAC", dna"ATGCTA", dna""]
+            for A in [DNAAlphabet{2}, RNAAlphabet{2}]
+                m = DynamicKmer{A, UInt64}(LongSequence{DNAAlphabet{4}}(s))
+                @test m == LongSequence{A}(s)
+            end
+        end
+    end
+
+    @testset "Generic alphabet" begin
+        for s in ["HE", "", "中Å!"]
+            m = DynamicKmer{CharAlphabet, UInt128}(s)
+            @test length(m) == length(s)
+            @test string(m) == s
+        end
+    end
+
+    @testset "From Kmer" begin
+        for s in [dna"TAGCTA", rna"UGCUGA", aa"PLKWM"]
+            kmer = Kmer{typeof(Alphabet(s)), length(s)}(s)
+            dkmer = DynamicKmer{typeof(Alphabet(s)), UInt64}(kmer)
+            @test dkmer == s
+            @test length(dkmer) == length(kmer)
+        end
+    end
+
+    @testset "To Kmer" begin
+        for s in [dna"TAGCTA", rna"UGCUGA", aa"PLKWM"]
+            dkmer = DynamicKmer{typeof(Alphabet(s)), UInt64}(s)
+            kmer = Kmer{typeof(Alphabet(s)), length(s)}(dkmer)
+            @test length(kmer) == length(dkmer)
+            @test string(dkmer) == string(kmer)
+            @test_throws MethodError kmer == dkmer
+        end
+    end
+
+    @testset "Capacity limits" begin
+        # Test that exceeding capacity throws
+        @test_throws Exception DynamicDNAKmer{UInt32}(dna"T"^30)
+        @test_throws Exception DynamicAAKmer{UInt32}(aa"A"^8)
+    end
+end
+
+@testset "Indexing and iteration" begin
+    @testset "Scalar indexing" begin
+        m = DynamicDNAKmer{UInt64}(dna"TAGCTGAC")
+        @test m[1] == DNA_T
+        @test m[3] == DNA_G
+        @test m[8] == DNA_C
+        @test first(m) == DNA_T
+        @test last(m) == DNA_C
+
+        @test_throws BoundsError m[0]
+        @test_throws BoundsError m[9]
+    end
+
+    @testset "Range indexing" begin
+        m = DynamicDNAKmer{UInt64}(dna"TAGCTGAC")
+        @test m[1:3] == DynamicDNAKmer{UInt64}(dna"TAG")
+        @test m[2:5] == DynamicDNAKmer{UInt64}(dna"AGCT")
+        @test m[6:8] == DynamicDNAKmer{UInt64}(dna"GAC")
+        @test m[1:0] == DynamicDNAKmer{UInt64}(dna"")
+
+        @test_throws BoundsError m[0:3]
+        @test_throws BoundsError m[6:9]
+    end
+
+    @testset "Iteration" begin
+        s = dna"TAGCTGAC"
+        m = DynamicDNAKmer{UInt64}(s)
+        @test collect(m) == collect(s)
+    end
+end
+
+@testset "Comparison and equality" begin
+    @testset "Equality" begin
+        @test DynamicDNAKmer{UInt64}(dna"TAG") == DynamicDNAKmer{UInt64}(dna"TAG")
+        @test DynamicDNAKmer{UInt64}(dna"TAG") != DynamicDNAKmer{UInt64}(dna"TAC")
+        @test DynamicDNAKmer{UInt64}(dna"") == DynamicDNAKmer{UInt64}(dna"")
+    end
+
+    @testset "Ordering" begin
+        @test DynamicDNAKmer{UInt64}(dna"TAG") < DynamicDNAKmer{UInt64}(dna"TGA")
+        @test DynamicDNAKmer{UInt64}(dna"AAA") < DynamicDNAKmer{UInt64}(dna"AAC")
+        @test DynamicDNAKmer{UInt64}(dna"TAG") > DynamicDNAKmer{UInt64}(dna"TAC")
+    end
+
+    @testset "Comparison of different lengths" begin
+        @test DynamicDNAKmer{UInt64}(dna"TAG") < DynamicDNAKmer{UInt64}(dna"TAGA")
+        @test DynamicDNAKmer{UInt64}(dna"TAGA") > DynamicDNAKmer{UInt64}(dna"TAG")
+    end
+end
+
+@testset "Integer conversion" begin
+    @testset "as_integer" begin
+        m1 = DynamicDNAKmer{UInt64}(dna"TAG")
+        u1 = as_integer(m1)
+        @test u1 isa Unsigned
+
+        m2 = DynamicDNAKmer{UInt64}(dna"TAC")
+        u2 = as_integer(m2)
+        @test u1 != u2
+
+        # Empty kmer
+        @test as_integer(DynamicDNAKmer{UInt64}(dna"")) == 0
+    end
+
+    @testset "from_integer" begin
+        for s in [dna"TAG", dna"TAGCTGA", dna"ATGCTAGC"]
+            m = DynamicDNAKmer{UInt64}(s)
+            u = as_integer(m)
+            m2 = from_integer(typeof(m), u, length(m))
+            @test m == m2
+        end
+
+        # Error on exceeding capacity
+        @test_throws Exception from_integer(DynamicDNAKmer{UInt32}, UInt32(0), 30)
+    end
+
+    @testset "Round-trip conversion" begin
+        for s in [dna"TAGCTGA", rna"UGCUGA", aa"PLKWM"]
+            m = DynamicKmer{typeof(Alphabet(s)), UInt64}(s)
+            u = as_integer(m)
+            m2 = from_integer(typeof(m), u, length(m))
+            @test m === m2
         end
     end
 end
 
-@testset "Misc" begin
-    s = dna"ATGCTGAC"
-    m = DynamicDNAKmer{UInt32}(s)
-    @test reverse_complement(m) == typeof(m)(reverse_complement(s))
+@testset "Hashing" begin
+    m1 = DynamicDNAKmer{UInt64}(dna"TAG")
+    m2 = DynamicDNAKmer{UInt64}(dna"TAG")
+    m3 = DynamicDNAKmer{UInt64}(dna"TAC")
+
+    # Same kmers hash to same value
+    @test hash(m1) == hash(m2)
+
+    # Different kmers likely hash to different values (not guaranteed but likely)
+    @test hash(m1) != hash(m3)
+
+    # Hash with seed
+    h1 = hash(m1, UInt(123))
+    h2 = hash(m1, UInt(456))
+    @test h1 != h2
+
+    # Length is part of hash
+    m1 = DynamicDNAKmer{UInt64}(dna"TCA")
+    m2 = DynamicDNAKmer{UInt64}(dna"TC")
+    @test hash(m1) != hash(m2)
+end
+
+@testset "Biological operations" begin
+    @testset "Reverse" begin
+        m = DynamicDNAKmer{UInt64}(dna"TAGCTGA")
+        @test reverse(m) == DynamicDNAKmer{UInt64}(dna"AGTCGAT")
+        @test reverse(DynamicDNAKmer{UInt64}(dna"")) == DynamicDNAKmer{UInt64}(dna"")
+    end
+
+    @testset "Complement" begin
+        m = DynamicDNAKmer{UInt64}(dna"TAGCTGA")
+        @test complement(m) == DynamicDNAKmer{UInt64}(dna"ATCGACT")
+
+        m2 = DynamicRNAKmer{UInt64}(rna"UAGCUGA")
+        @test complement(m2) == DynamicRNAKmer{UInt64}(rna"AUCGACU")
+    end
+
+    @testset "Reverse complement" begin
+        m = DynamicDNAKmer{UInt64}(dna"TAGCTGA")
+        @test reverse_complement(m) == DynamicDNAKmer{UInt64}(dna"TCAGCTA")
+    end
+
+    @testset "Canonical" begin
+        m1 = DynamicDNAKmer{UInt64}(dna"TAGCTGA")
+        m2 = DynamicDNAKmer{UInt64}(dna"TCAGCTA")
+        @test canonical(m1) == canonical(m2)
+        @test iscanonical(DynamicDNAKmer{UInt64}(dna"AATT"))
+        @test iscanonical(DynamicDNAKmer{UInt64}(dna"TTAA"))
+        @test iscanonical(empty(m1))
+        @test !iscanonical(DynamicDNAKmer{UInt64}(dna"TGGA"))
+    end
+end
+
+@testset "Counting" begin
+    @testset "Count GC" begin
+        @test count(isGC, DynamicDNAKmer{UInt64}(dna"TATCGGAGA")) == 4
+        @test count(isGC, DynamicDNAKmer{UInt64}(dna"TATATATAAAAA")) == 0
+        @test count(isGC, DynamicDNAKmer{UInt64}(dna"")) == 0
+
+        @test count(isGC, DynamicRNAKmer{UInt64}(rna"AUGUCGUAG")) == 4
+    end
+
+    @testset "Count symbols" begin
+        m = DynamicDNAKmer{UInt64}(dna"TAGCTGA")
+        @test count(==(DNA_A), m) == 2
+        @test count(==(DNA_T), m) == 2
+        @test count(==(DNA_G), m) == 2
+        @test count(==(DNA_C), m) == 1
+    end
+end
+
+@testset "shift_encoding" begin
+    m = DynamicDNAKmer{UInt32}(dna"TAGA")
+    enc = UInt32(BioSequences.encode(DNAAlphabet{2}(), DNA_C))
+    m2 = Kmers.shift_encoding(m, enc)
+    @test m2 == DynamicDNAKmer{UInt32}(dna"AGAC")
+    @test length(m2) == length(m)
+end
+
+@testset "Mixed integer types" begin
+    for U in [UInt8, UInt16, UInt32, UInt64, UInt128]
+        s = dna"TAG"
+        m = DynamicKmer{DNAAlphabet{2}, U}(s)
+        @test m == s
+        @test length(m) == 3
+    end
 end

--- a/test/dynamic.jl
+++ b/test/dynamic.jl
@@ -437,7 +437,7 @@ end
     @testset "Canonical" begin
         m1 = dmer"TAGCTGA"d
         m2 = dmer"TCAGCTA"d
-        @test canonical(m1) == canonical(m2)
+        @test canonical(m1) == canonical(m2) == m1
         @test iscanonical(dmer"AATT"d)
         @test iscanonical(dmer"TTAA"d)
         @test iscanonical(empty(m1))

--- a/test/dynamic.jl
+++ b/test/dynamic.jl
@@ -638,7 +638,7 @@ end
     # Test zero BPS: capacity should be clamped to typemax(Int)
     @test capacity(DynamicKmer{ZeroBPSAlphabet, UInt8}) == clamp(typemax(UInt8), Int)
     @test capacity(DynamicKmer{ZeroBPSAlphabet, UInt32}) == clamp(typemax(UInt32), Int)
-    @test capacity(DynamicKmer{ZeroBPSAlphabet, UInt128}) == clamp(typemax(UInt128), Int)
+    @test capacity(DynamicKmer{ZeroBPSAlphabet, UInt128}) == typemax(Int)
 
     # Test non-zero BPS: capacity should be in range 0:div(8 * sizeof(U), B)
     for (A, bps) in [(DNAAlphabet{2}, 2), (DNAAlphabet{4}, 4), (AminoAcidAlphabet, 8)]

--- a/test/dynamic.jl
+++ b/test/dynamic.jl
@@ -697,29 +697,29 @@ end
     @testset "Different genetic codes" begin
         # Vertebrate mitochondrial code: AGA and AGG are stop codons
         vert_mito = BioSequences.vertebrate_mitochondrial_genetic_code
-        @test translate(dmer"ATGAGA"d; code=vert_mito) == dmer"M*"a  # AGA is stop
+        @test translate(dmer"ATGAGA"d; code = vert_mito) == dmer"M*"a  # AGA is stop
 
         # Standard code: AGA and AGG code for R (Arginine)
         @test translate(dmer"ATGAGA"d) == dmer"MR"a
         @test translate(dmer"ATGAGG"d) == dmer"MR"a
 
         # Test with different backing types
-        @test translate(DynamicDNAKmer{UInt64}(dna"ATGAGA"); code=vert_mito) == dmer"M*"a
-        @test translate(DynamicRNAKmer{UInt32}(rna"AUGAGA"); code=vert_mito) == dmer"M*"a
+        @test translate(DynamicDNAKmer{UInt64}(dna"ATGAGA"); code = vert_mito) == dmer"M*"a
+        @test translate(DynamicRNAKmer{UInt32}(rna"AUGAGA"); code = vert_mito) == dmer"M*"a
 
         # Test with 4-bit alphabets
-        @test translate(DynamicKmer{DNAAlphabet{4}, UInt64}(dna"ATGAGA"); code=vert_mito) == dmer"M*"a
+        @test translate(DynamicKmer{DNAAlphabet{4}, UInt64}(dna"ATGAGA"); code = vert_mito) == dmer"M*"a
     end
 
     # alternative_start flag
     @testset "alternative_start" begin
         # Without alternative_start: TTG codes for L (Leucine)
-        @test translate(dmer"TTGCCC"d; alternative_start=false) == dmer"LP"a
-        @test translate(dmer"UUGCCC"r; alternative_start=false) == dmer"LP"a
+        @test translate(dmer"TTGCCC"d; alternative_start = false) == dmer"LP"a
+        @test translate(dmer"UUGCCC"r; alternative_start = false) == dmer"LP"a
 
         # With alternative_start: first codon becomes M regardless
-        @test translate(dmer"TTGCCC"d; alternative_start=true) == dmer"MP"a
-        @test translate(dmer"UUGCCC"r; alternative_start=true) == dmer"MP"a
+        @test translate(dmer"TTGCCC"d; alternative_start = true) == dmer"MP"a
+        @test translate(dmer"UUGCCC"r; alternative_start = true) == dmer"MP"a
     end
 
     # Ambiguous codons (only for 4-bit alphabets)
@@ -729,13 +729,13 @@ end
         @test translate(d_ambig) == dmer"KTAJBX"a
 
         # With allow_ambiguous_codons=false, ambiguous codons throw
-        @test_throws Exception translate(d_ambig; allow_ambiguous_codons=false)
+        @test_throws Exception translate(d_ambig; allow_ambiguous_codons = false)
 
         # Test various ambiguous nucleotides
         # W = A or T, so TWG could be AAG (K) or TAG (*)
         # With allow_ambiguous, should give X (ambiguous)
         d_w = DynamicKmer{DNAAlphabet{4}, UInt64}(dna"ATGTWG")
-        result_w = translate(d_w; allow_ambiguous_codons=true)
+        result_w = translate(d_w; allow_ambiguous_codons = true)
         @test length(result_w) == 2  # M and something
     end
 

--- a/test/dynamic.jl
+++ b/test/dynamic.jl
@@ -29,6 +29,11 @@ using BioSequences
         d = DynamicDNAKmer{UInt}(dna"ATGTCGTTAGT")
         @test DynamicRNAKmer(d) == d
         @test DynamicRNAKmer{UInt64}(d) == d
+
+        # From a large kmer
+        m = mer"TAGTGCTGTAGTAGTGCTGTATGATGTCTGCATGC"d
+        dm = DynamicDNAKmer{UInt128}(m)
+        @test LongSequence(m) == LongSequence(dm)
     end
 
     @testset "Two to four bit alphabet" begin

--- a/test/dynamic.jl
+++ b/test/dynamic.jl
@@ -202,6 +202,19 @@ end
         @test m32_1 < m32_3
         @test m64_1 < m32_3
         @test cmp(m32_1, m32_3) < 0
+
+        # Also for AA types
+        s1 = aa"KPRCRLF"
+        s2 = aa"KPRCRLFAAA"
+
+        m64_1 = DynamicAAKmer{UInt64}(s1)
+        m128_1 = DynamicAAKmer{UInt128}(s1)
+        m128_2 = DynamicAAKmer{UInt128}(s2)
+
+        @test m64_1 == m128_1
+        @test cmp(m64_1, m128_1) == 0
+        @test m128_1 != m128_2
+        @test m128_1 < m128_2
     end
 end
 
@@ -383,6 +396,12 @@ end
         @test count(==(DNA_T), m) == 2
         @test count(==(DNA_G), m) == 2
         @test count(==(DNA_C), m) == 1
+
+        m = DynamicAAKmer{UInt128}(aa"WLAKWVMARQKW")
+        @test count(==(AA_W), m) == 3
+        @test count(==(AA_Q), m) == 1
+        @test count(==(AA_A), m) == 2
+        @test count(==(AA_C), m) == 0
     end
 end
 

--- a/test/dynamic.jl
+++ b/test/dynamic.jl
@@ -172,6 +172,37 @@ end
         @test cmp(DynamicDNAKmer{UInt64}(dna"TAG"), DynamicDNAKmer{UInt64}(dna"TAGA")) < 0
         @test cmp(DynamicDNAKmer{UInt64}(dna"TAGA"), DynamicDNAKmer{UInt64}(dna"TAG")) > 0
     end
+
+    @testset "Comparison across different integer types" begin
+        s1 = dna"TAG"
+        s2 = dna"TAC"
+        s3 = dna"TAGA"
+
+        m32_1 = DynamicDNAKmer{UInt32}(s1)
+        m64_1 = DynamicDNAKmer{UInt64}(s1)
+        m32_2 = DynamicDNAKmer{UInt32}(s2)
+        m64_2 = DynamicDNAKmer{UInt64}(s2)
+
+        # Test equality across types
+        @test m32_1 == m64_1
+        @test m32_2 == m64_2
+        @test m32_1 != m64_2
+
+        # Test ordering across types
+        @test m32_2 < m64_1  # TAC < TAG
+        @test m64_1 > m32_2  # TAG > TAC
+
+        # Test cmp across types
+        @test cmp(m32_1, m64_1) == 0
+        @test cmp(m32_2, m64_1) < 0
+        @test cmp(m64_1, m32_2) > 0
+
+        # Test with different lengths
+        m32_3 = DynamicDNAKmer{UInt32}(s3)
+        @test m32_1 < m32_3
+        @test m64_1 < m32_3
+        @test cmp(m32_1, m32_3) < 0
+    end
 end
 
 @testset "Integer conversion" begin
@@ -370,4 +401,9 @@ end
         @test m == s
         @test length(m) == 3
     end
+end
+
+@testset "Misc" begin
+    d = DynamicAAKmer{UInt32}("WPK")
+    @test only([d]') === d
 end

--- a/test/dynamic.jl
+++ b/test/dynamic.jl
@@ -1,0 +1,45 @@
+using Test
+using Kmers
+using BioSequences
+
+@testset "Construction" begin
+    for s in [
+            dna"ATGTCGTTAGT",
+            dna"",
+            dna"YATGC-ATGwTCTDV",
+            rna"AUGUCGAGUGUAUGC",
+            rna"AUGCWSYGANN--CA",
+            aa"KWOP",
+            aa"",
+            aa"TYAPC",
+
+        ]
+        for i in (s, string(s), (i for i in s))
+            m = DynamicKmer{typeof(Alphabet(s)), UInt64}(i)
+            @test length(m) == length(i)
+            @test m == s
+        end
+    end
+
+    # Two to four alphabet
+    for s in Any[
+        dna"ATGCTGTGACCA",
+        dna"ATGTCGA",
+        dna"",
+    ]
+        for A in Any[DNAAlphabet, RNAAlphabet]
+            for (srcB, dstB) in [(2, 4), (4, 2)]
+                src = LongSequence{A{srcB}}(s)
+                dst = DynamicKmer{A{dstB}, UInt64}(src)
+
+                @test src == dst
+            end
+        end
+    end
+end
+
+@testset "Misc" begin
+    s = dna"ATGCTGAC"
+    m = DynamicDNAKmer{UInt32}(s)
+    @test reverse_complement(m) == typeof(m)(reverse_complement(s))
+end

--- a/test/dynamic.jl
+++ b/test/dynamic.jl
@@ -21,6 +21,11 @@ using BioSequences
             end
         end
 
+        # Test macro equivalence with constructor
+        @test dmer"ATGTCGTTAGT"d == DynamicDNAKmer{UInt64}(dna"ATGTCGTTAGT")
+        @test dmer"AUGUCGAGUGUAUGC"r == DynamicRNAKmer{UInt64}(rna"AUGUCGAGUGUAUGC")
+        @test dmer"KWOP"a == DynamicAAKmer{UInt64}(aa"KWOP")
+
         d = DynamicDNAKmer{UInt}(dna"ATGTCGTTAGT")
         @test DynamicRNAKmer(d) == d
         @test DynamicRNAKmer{UInt64}(d) == d
@@ -72,7 +77,7 @@ using BioSequences
     @testset "From DynamicKmer" begin
         # Same backing type, same alphabet
         s = dna"TAGCTGA"
-        d1 = DynamicDNAKmer{UInt64}(s)
+        d1 = dmer"TAGCTGA"d
         d2 = DynamicDNAKmer{UInt64}(d1)
         @test d2 == d1
         @test d2 === d1  # Should be identical
@@ -93,7 +98,7 @@ using BioSequences
         @test d32_narrow == dna"TAGC"
 
         # Same alphabet family (DNA/RNA), different alphabets
-        d_dna = DynamicDNAKmer{UInt64}(dna"ATGTCGTTAGT")
+        d_dna = dmer"ATGTCGTTAGT"d
         d_rna = DynamicRNAKmer{UInt64}(d_dna)
         @test d_rna == d_dna
         @test length(d_rna) == length(d_dna)
@@ -105,7 +110,7 @@ using BioSequences
         @test length(d_rna64) == length(d_dna32)
 
         # Test with amino acids
-        aa_d64 = DynamicAAKmer{UInt64}(aa"KWOP")
+        aa_d64 = dmer"KWOP"a
         aa_d128 = DynamicAAKmer{UInt128}(aa_d64)
         @test aa_d128 == aa_d64
         @test length(aa_d128) == length(aa_d64)
@@ -157,7 +162,7 @@ using BioSequences
         @test string(dkmer_aa) == string(kmer_aa)
 
         # Test error on length mismatch
-        dkmer = DynamicDNAKmer{UInt64}(dna"TAG")
+        dkmer = dmer"TAG"d
         @test_throws Exception Kmer{DNAAlphabet{2}, 5, 1}(dkmer)
     end
 
@@ -170,7 +175,7 @@ end
 
 @testset "Indexing and iteration" begin
     @testset "Scalar indexing" begin
-        m = DynamicDNAKmer{UInt64}(dna"TAGCTGAC")
+        m = dmer"TAGCTGAC"d
         @test m[1] == DNA_T
         @test m[3] == DNA_G
         @test m[8] == DNA_C
@@ -182,11 +187,11 @@ end
     end
 
     @testset "Range indexing" begin
-        m = DynamicDNAKmer{UInt64}(dna"TAGCTGAC")
-        @test m[1:3] == DynamicDNAKmer{UInt64}(dna"TAG")
-        @test m[2:5] == DynamicDNAKmer{UInt64}(dna"AGCT")
-        @test m[6:8] == DynamicDNAKmer{UInt64}(dna"GAC")
-        @test m[1:0] == DynamicDNAKmer{UInt64}(dna"")
+        m = dmer"TAGCTGAC"d
+        @test m[1:3] == dmer"TAG"d
+        @test m[2:5] == dmer"AGCT"d
+        @test m[6:8] == dmer"GAC"d
+        @test m[1:0] == dmer""d
 
         @test_throws BoundsError m[0:3]
         @test_throws BoundsError m[6:9]
@@ -194,42 +199,42 @@ end
 
     @testset "Iteration" begin
         s = dna"TAGCTGAC"
-        m = DynamicDNAKmer{UInt64}(s)
+        m = dmer"TAGCTGAC"d
         @test collect(m) == collect(s)
     end
 end
 
 @testset "Comparison and equality" begin
     @testset "Equality" begin
-        @test DynamicDNAKmer{UInt64}(dna"TAG") == DynamicDNAKmer{UInt64}(dna"TAG")
-        @test DynamicDNAKmer{UInt64}(dna"TAG") != DynamicDNAKmer{UInt64}(dna"TAC")
-        @test DynamicDNAKmer{UInt64}(dna"") == DynamicDNAKmer{UInt64}(dna"")
+        @test dmer"TAG"d == dmer"TAG"d
+        @test dmer"TAG"d != dmer"TAC"d
+        @test dmer""d == dmer""d
     end
 
     @testset "Ordering" begin
-        @test DynamicDNAKmer{UInt64}(dna"TAG") < DynamicDNAKmer{UInt64}(dna"TGA")
-        @test DynamicDNAKmer{UInt64}(dna"AAA") < DynamicDNAKmer{UInt64}(dna"AAC")
-        @test DynamicDNAKmer{UInt64}(dna"TAG") > DynamicDNAKmer{UInt64}(dna"TAC")
+        @test dmer"TAG"d < dmer"TGA"d
+        @test dmer"AAA"d < dmer"AAC"d
+        @test dmer"TAG"d > dmer"TAC"d
     end
 
     @testset "Comparison of different lengths" begin
-        @test DynamicDNAKmer{UInt64}(dna"TAG") < DynamicDNAKmer{UInt64}(dna"TAGA")
-        @test DynamicDNAKmer{UInt64}(dna"TAGA") > DynamicDNAKmer{UInt64}(dna"TAG")
+        @test dmer"TAG"d < dmer"TAGA"d
+        @test dmer"TAGA"d > dmer"TAG"d
     end
 
     @testset "cmp function" begin
         # Test cmp returns -1, 0, or 1
-        @test cmp(DynamicDNAKmer{UInt64}(dna"TAG"), DynamicDNAKmer{UInt64}(dna"TAG")) == 0
-        @test cmp(DynamicDNAKmer{UInt64}(dna"TAG"), DynamicDNAKmer{UInt64}(dna"TGA")) < 0
-        @test cmp(DynamicDNAKmer{UInt64}(dna"TGA"), DynamicDNAKmer{UInt64}(dna"TAG")) > 0
+        @test cmp(dmer"TAG"d, dmer"TAG"d) == 0
+        @test cmp(dmer"TAG"d, dmer"TGA"d) < 0
+        @test cmp(dmer"TGA"d, dmer"TAG"d) > 0
 
         # Test with RNA
-        @test cmp(DynamicRNAKmer{UInt64}(rna"UAG"), DynamicRNAKmer{UInt64}(rna"UAG")) == 0
-        @test cmp(DynamicRNAKmer{UInt64}(rna"UAG"), DynamicRNAKmer{UInt64}(rna"UGA")) < 0
+        @test cmp(dmer"UAG"r, dmer"UAG"r) == 0
+        @test cmp(dmer"UAG"r, dmer"UGA"r) < 0
 
         # Test with different lengths
-        @test cmp(DynamicDNAKmer{UInt64}(dna"TAG"), DynamicDNAKmer{UInt64}(dna"TAGA")) < 0
-        @test cmp(DynamicDNAKmer{UInt64}(dna"TAGA"), DynamicDNAKmer{UInt64}(dna"TAG")) > 0
+        @test cmp(dmer"TAG"d, dmer"TAGA"d) < 0
+        @test cmp(dmer"TAGA"d, dmer"TAG"d) > 0
     end
 
     @testset "Comparison across different integer types" begin
@@ -279,16 +284,16 @@ end
 
 @testset "Integer conversion" begin
     @testset "as_integer" begin
-        m1 = DynamicDNAKmer{UInt64}(dna"TAG")
+        m1 = dmer"TAG"d
         u1 = as_integer(m1)
         @test u1 isa Unsigned
 
-        m2 = DynamicDNAKmer{UInt64}(dna"TAC")
+        m2 = dmer"TAC"d
         u2 = as_integer(m2)
         @test u1 != u2
 
         # Empty kmer
-        @test as_integer(DynamicDNAKmer{UInt64}(dna"")) == 0
+        @test as_integer(dmer""d) == 0
     end
 
     @testset "from_integer" begin
@@ -314,9 +319,9 @@ end
 end
 
 @testset "Hashing" begin
-    m1 = DynamicDNAKmer{UInt64}(dna"TAG")
-    m2 = DynamicDNAKmer{UInt64}(dna"TAG")
-    m3 = DynamicDNAKmer{UInt64}(dna"TAC")
+    m1 = dmer"TAG"d
+    m2 = dmer"TAG"d
+    m3 = dmer"TAC"d
 
     # Same kmers hash to same value
     @test hash(m1) == hash(m2)
@@ -332,14 +337,14 @@ end
     # Length must be part of hash: TCA and TC have identical coding bits
     # (since A encodes to 00, which looks like padding), but different lengths.
     # They must hash differently despite having the same as_integer representation.
-    m1 = DynamicDNAKmer{UInt64}(dna"TCA")
-    m2 = DynamicDNAKmer{UInt64}(dna"TC")
+    m1 = dmer"TCA"d
+    m2 = dmer"TC"d
     @test hash(m1) != hash(m2)
 
     @testset "fx_hash" begin
-        m1 = DynamicDNAKmer{UInt64}(dna"TAG")
-        m2 = DynamicDNAKmer{UInt64}(dna"TAG")
-        m3 = DynamicDNAKmer{UInt64}(dna"TAC")
+        m1 = dmer"TAG"d
+        m2 = dmer"TAG"d
+        m3 = dmer"TAC"d
 
         # Same kmers should produce same fx_hash
         @test Kmers.fx_hash(m1, UInt64(0)) == Kmers.fx_hash(m2, UInt64(0))
@@ -353,8 +358,8 @@ end
         # Length must be part of hash: TCA and TC have identical coding bits
         # (since A encodes to 00, which looks like padding), but different lengths.
         # They must hash differently despite having the same as_integer representation.
-        m1 = DynamicDNAKmer{UInt64}(dna"TCA")
-        m2 = DynamicDNAKmer{UInt64}(dna"TC")
+        m1 = dmer"TCA"d
+        m2 = dmer"TC"d
         @test Kmers.fx_hash(m1, UInt64(0)) != Kmers.fx_hash(m2, UInt64(0))
     end
 end
@@ -363,15 +368,15 @@ end
     @testset "Reverse" begin
         # Test with 2-bit DNA
         s = dna"TAGCTGA"
-        m = DynamicDNAKmer{UInt64}(s)
+        m = dmer"TAGCTGA"d
         @test reverse(m) == DynamicDNAKmer{UInt64}(reverse(s))
 
         # Test empty sequence
-        @test reverse(DynamicDNAKmer{UInt64}(dna"")) == DynamicDNAKmer{UInt64}(dna"")
+        @test reverse(dmer""d) == dmer""d
 
         # Test with 2-bit RNA
         s_rna = rna"UAGCUGA"
-        m_rna = DynamicRNAKmer{UInt64}(s_rna)
+        m_rna = dmer"UAGCUGA"r
         @test reverse(m_rna) == DynamicRNAKmer{UInt64}(reverse(s_rna))
 
         # Test with 4-bit DNA
@@ -381,19 +386,19 @@ end
 
         # Test with amino acids
         s_aa = aa"KWOP"
-        m_aa = DynamicAAKmer{UInt64}(s_aa)
+        m_aa = dmer"KWOP"a
         @test reverse(m_aa) == DynamicAAKmer{UInt64}(reverse(s_aa))
     end
 
     @testset "Complement" begin
         # Test with 2-bit DNA
         s = dna"TAGCTGA"
-        m = DynamicDNAKmer{UInt64}(s)
+        m = dmer"TAGCTGA"d
         @test complement(m) == DynamicDNAKmer{UInt64}(complement(s))
 
         # Test with 2-bit RNA
         s_rna = rna"UAGCUGA"
-        m_rna = DynamicRNAKmer{UInt64}(s_rna)
+        m_rna = dmer"UAGCUGA"r
         @test complement(m_rna) == DynamicRNAKmer{UInt64}(complement(s_rna))
 
         # Test with 4-bit DNA (includes ambiguous bases)
@@ -410,12 +415,12 @@ end
     @testset "Reverse complement" begin
         # Test with 2-bit DNA
         s = dna"TAGCTGA"
-        m = DynamicDNAKmer{UInt64}(s)
+        m = dmer"TAGCTGA"d
         @test reverse_complement(m) == DynamicDNAKmer{UInt64}(reverse_complement(s))
 
         # Test with 2-bit RNA
         s_rna = rna"UAGCUGA"
-        m_rna = DynamicRNAKmer{UInt64}(s_rna)
+        m_rna = dmer"UAGCUGA"r
         @test reverse_complement(m_rna) == DynamicRNAKmer{UInt64}(reverse_complement(s_rna))
 
         # Test with 4-bit DNA
@@ -430,27 +435,27 @@ end
     end
 
     @testset "Canonical" begin
-        m1 = DynamicDNAKmer{UInt64}(dna"TAGCTGA")
-        m2 = DynamicDNAKmer{UInt64}(dna"TCAGCTA")
+        m1 = dmer"TAGCTGA"d
+        m2 = dmer"TCAGCTA"d
         @test canonical(m1) == canonical(m2)
-        @test iscanonical(DynamicDNAKmer{UInt64}(dna"AATT"))
-        @test iscanonical(DynamicDNAKmer{UInt64}(dna"TTAA"))
+        @test iscanonical(dmer"AATT"d)
+        @test iscanonical(dmer"TTAA"d)
         @test iscanonical(empty(m1))
-        @test !iscanonical(DynamicDNAKmer{UInt64}(dna"TGGA"))
+        @test !iscanonical(dmer"TGGA"d)
     end
 end
 
 @testset "Counting" begin
     @testset "Count GC" begin
-        @test count(isGC, DynamicDNAKmer{UInt64}(dna"TATCGGAGA")) == 4
-        @test count(isGC, DynamicDNAKmer{UInt64}(dna"TATATATAAAAA")) == 0
-        @test count(isGC, DynamicDNAKmer{UInt64}(dna"")) == 0
+        @test count(isGC, dmer"TATCGGAGA"d) == 4
+        @test count(isGC, dmer"TATATATAAAAA"d) == 0
+        @test count(isGC, dmer""d) == 0
 
-        @test count(isGC, DynamicRNAKmer{UInt64}(rna"AUGUCGUAG")) == 4
+        @test count(isGC, dmer"AUGUCGUAG"r) == 4
     end
 
     @testset "Count symbols" begin
-        m = DynamicDNAKmer{UInt64}(dna"TAGCTGA")
+        m = dmer"TAGCTGA"d
         @test count(==(DNA_A), m) == 2
         @test count(==(DNA_T), m) == 2
         @test count(==(DNA_G), m) == 2

--- a/test/dynamic.jl
+++ b/test/dynamic.jl
@@ -609,6 +609,28 @@ end
     @test_throws ArgumentError pop_first(DynamicAAKmer{UInt128}(aa""))
 end
 
+@testset "setindex" begin
+    # Basic functionality
+    d = dmer"TAGCTGA"d
+    @test Base.setindex(d, DNA_C, 1) == dmer"CAGCTGA"d
+    @test Base.setindex(d, DNA_A, 4) == dmer"TAGATGA"d
+    @test Base.setindex(d, DNA_T, 7) == dmer"TAGCTGT"d
+    @test d == dmer"TAGCTGA"d  # Original unchanged
+
+    # Different alphabets and backing types
+    @test Base.setindex(dmer"AUGC"r, RNA_G, 2) == dmer"AGGC"r
+    @test Base.setindex(dmer"KWOP"a, AA_L, 3) == dmer"KWLP"a
+    @test Base.setindex(DynamicDNAKmer{UInt32}(dna"ATGC"), DNA_G, 2) == DynamicDNAKmer{UInt32}(dna"AGGC")
+
+    # Type conversion
+    @test Base.setindex(dmer"TAG"d, 'C', 2) == dmer"TCG"d
+
+    # Bounds checking
+    @test_throws BoundsError Base.setindex(dmer"TAGC"d, DNA_A, 0)
+    @test_throws BoundsError Base.setindex(dmer"TAGC"d, DNA_A, 5)
+    @test_throws BoundsError Base.setindex(dmer""d, DNA_A, 1)
+end
+
 @testset "capacity" begin
     # Create a zero-BPS alphabet for testing
     struct ZeroBPSAlphabet <: Alphabet end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ struct CharAlphabet <: Alphabet end
 Base.eltype(::Type{CharAlphabet}) = CharSymbol
 BioSequences.symbols(::CharAlphabet) = ntuple(i -> CharSymbol(Char(i - 1)), Val{128}())
 BioSequences.encode(::CharAlphabet, c::CharSymbol) = reinterpret(UInt32, c.x) % UInt
-BioSequences.decode(::CharAlphabet, c::UInt) = CharSymbol(reinterpret(Char, c % UInt32))
+BioSequences.decode(::CharAlphabet, c::Unsigned) = CharSymbol(reinterpret(Char, c % UInt32))
 BioSequences.BitsPerSymbol(::CharAlphabet) = BioSequences.BitsPerSymbol{32}()
 
 struct GenericNucAlphabet <: NucleicAcidAlphabet{8} end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1028,6 +1028,46 @@ end
 
         @test_throws MethodError count(isGC, mer"ATATA"a) # amino acid mer
     end
+
+    @testset "Count symbols" begin
+        # Test with 2-bit DNA
+        m = mer"TAGCTGA"d
+        @test count(==(DNA_A), m) == 2
+        @test count(==(DNA_T), m) == 2
+        @test count(==(DNA_G), m) == 2
+        @test count(==(DNA_C), m) == 1
+
+        # Test with 2-bit RNA
+        m_rna = mer"UAGCUGA"r
+        @test count(==(RNA_A), m_rna) == 2
+        @test count(==(RNA_U), m_rna) == 2
+        @test count(==(RNA_G), m_rna) == 2
+        @test count(==(RNA_C), m_rna) == 1
+
+        # Test with amino acids
+        m_aa = mer"KWOPPLKW"a
+        @test count(==(AA_K), m_aa) == 2
+        @test count(==(AA_W), m_aa) == 2
+        @test count(==(AA_P), m_aa) == 2
+        @test count(==(AA_L), m_aa) == 1
+        @test count(==(AA_O), m_aa) == 1
+
+        # Test symbols not present (should be zero)
+        @test count(==(DNA_C), mer"TAGTAG"d) == 0
+        @test count(==(RNA_G), mer"UUUAAA"r) == 0
+        @test count(==(AA_M), mer"KWOP"a) == 0
+
+        # Test edge cases
+        @test count(==(DNA_A), mer""d) == 0
+        @test count(==(DNA_A), mer"AAAA"d) == 4
+
+        # Test with longer kmers (N > 1)
+        m_long = mer"TAGCTAGCTAGCTAGCTAGCTAGCTAGCTAGCT"d  # 33 bases
+        @test count(==(DNA_A), m_long) == 8
+        @test count(==(DNA_T), m_long) == 9
+        @test count(==(DNA_G), m_long) == 8
+        @test count(==(DNA_C), m_long) == 8
+    end
 end
 
 @testset "Dynamic kmers" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -419,19 +419,19 @@ end
     @testset "Setindex" begin
         mer = mer"PLQVAK"a
         setindex = Base.setindex
-        @test setindex(mer, 3, AA_K) == mer"PLKVAK"a
-        @test setindex(mer, 1, AA_R) == mer"RLQVAK"a
-        @test setindex(mer, 6, AA_M) == mer"PLQVAM"a
-        @test_throws BoundsError setindex(mer, 0, AA_K)
-        @test_throws BoundsError setindex(mer, 7, AA_K)
+        @test setindex(mer, AA_K, 3) == mer"PLKVAK"a
+        @test setindex(mer, AA_R, 1) == mer"RLQVAK"a
+        @test setindex(mer, AA_M, 6) == mer"PLQVAM"a
+        @test_throws BoundsError setindex(mer, AA_K, 0)
+        @test_throws BoundsError setindex(mer, AA_K, 7)
 
         mer = mer"ATGTCGTGA"d
-        @test setindex(mer, 1, DNA_T) == mer"TTGTCGTGA"d
-        @test setindex(mer, 5, DNA_C) == mer"ATGTCGTGA"d
-        @test setindex(mer, 5, DNA_A) == mer"ATGTAGTGA"d
+        @test setindex(mer, DNA_T, 1) == mer"TTGTCGTGA"d
+        @test setindex(mer, DNA_C, 5) == mer"ATGTCGTGA"d
+        @test setindex(mer, DNA_A, 5) == mer"ATGTAGTGA"d
 
         mer = mer"PLAKCVMARYKW"a
-        @test setindex(mer, 10, AA_Q) == mer"PLAKCVMARQKW"a
+        @test setindex(mer, AA_Q, 10) == mer"PLAKCVMARQKW"a
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1030,4 +1030,8 @@ end
     end
 end
 
+@testset "Dynamic kmers" begin
+    include("dynamic.jl")
+end
+
 end # module


### PR DESCRIPTION
This type adds `Oligomer`, a kmer backed by a single unsigned integer. The length is encoded in parts of the integer's bits.
This is useful for code using a small range of kmer lengths, which would other- wise cause type instability.
One user could be to represent primers, or immunogenic peptides.

I tried to back oligos with an `NTuple` like kmers are, but it's very hard to made the code efficient and type stable, so I had to resort to backing it by a single unsigned integer.

## TODO
Make Oligomer on level with Kmer.

- [ ] Restructure files, such that Oligomer is not in its own little file
- [ ] Go through all non-iterator code and check if Oligomer also needs this
- [ ] Implement construction utils for Oligos
- [ ] Make kmer iterators generic over Kmer / Oligomer